### PR TITLE
Fix dependencies for common-test

### DIFF
--- a/packages/common-hapi/package.json
+++ b/packages/common-hapi/package.json
@@ -21,12 +21,12 @@
   "dependencies": {
     "@hapi/bell": "^12.3.0",
     "@hapi/cookie": "^11.0.2",
-    "@types/hapi__hapi": "^20.0.9",
-    "@types/hapi__inert": "^5.2.3",
     "@hapi/hapi": "^20.2.2",
     "@hapi/inert": "^6.0.4",
     "@paradoxical-io/common-server": "workspace:packages/common-server",
     "@paradoxical-io/types": "workspace:packages/types",
+    "@types/hapi__hapi": "^20.0.9",
+    "@types/hapi__inert": "^5.2.3",
     "humanize-duration": "^3.21.0",
     "joi": "^17.4.2",
     "node-cache": "^5.1.2"

--- a/packages/common-test/package.json
+++ b/packages/common-test/package.json
@@ -19,8 +19,7 @@
   "author": "Anton Kropp",
   "license": "MIT",
   "devDependencies": {
-    "@types/lodash": "4.14.168",
-    "lodash": "^4.17.21"
+    "@types/lodash": "4.14.168"
   },
   "lint-staged": {
     "*.ts": [
@@ -28,6 +27,10 @@
     ]
   },
   "dependencies": {
-    "@paradoxical-io/types": "workspace:packages/types"
+    "@paradoxical-io/types": "workspace:packages/types",
+    "lodash": "^4.17.21"
+  },
+  "peerDependencies": {
+    "jest": "^26.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,6 +1833,8 @@ __metadata:
     "@paradoxical-io/types": "workspace:packages/types"
     "@types/lodash": 4.14.168
     lodash: ^4.17.21
+  peerDependencies:
+    jest: ^26.4.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
At a minimum, `lodash` would need to be a `peerDependency`, but I don't think it meets the bar as a dependency we can assume to be in use by every package that depends on `common-test`. `jest`, however, I think does meet that bar, because `common-test` is a collection of jest specific code.

Without this, a package that depends on `common-test` won't get `lodash` installed alongside. 