### PR TITLE
Decouple common-aws from environment and add subpath exports

### DIFF
--- a/packages/common-aws/README.md
+++ b/packages/common-aws/README.md
@@ -61,7 +61,7 @@ import { S3SecureStore, downloadObject } from '@paradoxical-io/common-aws';
 
 const secureStore = new S3SecureStore({
   s3Bucket: 'my-bucket',
-  kmsKeyID: 'arn:aws:kms:...'
+  kmsKeyID: 'arn:aws:kms:...',
 });
 
 await secureStore.set('sensitive-data', Buffer.from('secret'));
@@ -128,7 +128,7 @@ import { CloudfrontPrivateAccess } from '@paradoxical-io/common-aws';
 const cloudfront = new CloudfrontPrivateAccess({
   distributionUrl: 'https://d123.cloudfront.net',
   privateKey: '...',
-  publicKeyId: 'KEY123'
+  publicKeyId: 'KEY123',
 });
 
 const cookies = await cloudfront.generateCookies(expiresAt);
@@ -150,7 +150,7 @@ const taskId = await cwManager.createExportTask({
   s3Bucket: 'logs-bucket',
   logGroupName: '/aws/lambda/my-function',
   from: startTime,
-  to: endTime
+  to: endTime,
 });
 ```
 
@@ -165,9 +165,7 @@ WebSocket connection management for API Gateway:
 ```typescript
 import { ApiGatewayWebsocket } from '@paradoxical-io/common-aws';
 
-const websocket = ApiGatewayWebsocket.createEndpoint(
-  'wss://abc123.execute-api.us-east-1.amazonaws.com/prod'
-);
+const websocket = ApiGatewayWebsocket.createEndpoint('wss://abc123.execute-api.us-east-1.amazonaws.com/prod');
 
 await websocket.publish(connectionId, { message: 'Hello!' });
 ```
@@ -186,7 +184,7 @@ import { defaultValueProvider } from '@paradoxical-io/common-aws';
 const valueProvider = await defaultValueProvider();
 const dbPassword = await valueProvider.get({
   type: 'ssm',
-  key: '/prod/database/password'
+  key: '/prod/database/password',
 });
 ```
 
@@ -243,8 +241,8 @@ const s3 = new S3Client({
   region: 'us-east-1',
   credentials: {
     accessKeyId: '...',
-    secretAccessKey: '...'
-  }
+    secretAccessKey: '...',
+  },
 });
 ```
 
@@ -276,15 +274,39 @@ Metrics integrate with Datadog by default but can be customized.
 
 ## Dependencies
 
-This package uses AWS SDK v3 and requires the following peer dependencies:
+All AWS SDK clients, `@paradoxical-io/common-server`, `aws-lambda`, and `datadog-lambda-js` are **peer dependencies**. You must install only the packages required by the subpath you import. This avoids pulling in the entire AWS SDK or heavy dependencies when you only need a single module.
 
-- Node.js 14 or higher
-- TypeScript 4.5 or higher (for development)
+For example, if you only use `@paradoxical-io/common-aws/dynamo/keys`:
 
-Core dependencies include:
-- `@aws-sdk/client-*` - AWS SDK v3 clients
-- `@paradoxical-io/types` - Shared type definitions
-- `@paradoxical-io/common-server` - Server utilities
+```bash
+yarn add @paradoxical-io/common-aws @aws-sdk/client-dynamodb @aws/dynamodb-data-mapper-annotations
+```
+
+If you use `@paradoxical-io/common-aws/sqs`, you also need `@paradoxical-io/common-server`:
+
+```bash
+yarn add @paradoxical-io/common-aws @aws-sdk/client-sqs @paradoxical-io/common-server
+```
+
+### Subpath Exports
+
+Import only the module you need to keep your dependency footprint minimal:
+
+| Subpath                                      | Required Peer Dependencies                                                   |
+| -------------------------------------------- | ---------------------------------------------------------------------------- |
+| `@paradoxical-io/common-aws/dynamo/keys`     | `@aws-sdk/client-dynamodb`, `@aws/dynamodb-data-mapper-annotations`          |
+| `@paradoxical-io/common-aws/dynamo`          | Above + `@paradoxical-io/common-server`                                      |
+| `@paradoxical-io/common-aws/monitoring`      | (none beyond core)                                                           |
+| `@paradoxical-io/common-aws/cloudfront`      | `@aws-sdk/cloudfront-signer`                                                 |
+| `@paradoxical-io/common-aws/cloudwatch`      | `@aws-sdk/client-cloudwatch-logs`                                            |
+| `@paradoxical-io/common-aws/sns`             | `@aws-sdk/client-sns`                                                        |
+| `@paradoxical-io/common-aws/sqs`             | `@aws-sdk/client-sqs`, `@paradoxical-io/common-server`                       |
+| `@paradoxical-io/common-aws/s3`              | `@aws-sdk/client-s3`, `@aws-sdk/client-kms`, `@paradoxical-io/common-server` |
+| `@paradoxical-io/common-aws/parameter-store` | `@aws-sdk/client-ssm`, `@paradoxical-io/common-server`                       |
+| `@paradoxical-io/common-aws/lambda`          | `aws-lambda`, `datadog-lambda-js`                                            |
+| `@paradoxical-io/common-aws/gateway`         | `@aws-sdk/client-apigatewaymanagementapi`                                    |
+
+The root import (`@paradoxical-io/common-aws`) re-exports everything and requires all peer dependencies.
 
 ## Configuration
 

--- a/packages/common-aws/package.json
+++ b/packages/common-aws/package.json
@@ -1,9 +1,71 @@
 {
   "name": "@paradoxical-io/common-aws",
-  "version": "2.9.0",
-  "description": "Common aws for paradox services",
+  "version": "3.0.0",
+  "description": "Common aws utilities",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./dynamo/keys": {
+      "types": "./dist/dynamo/keys/index.d.ts",
+      "import": "./dist/dynamo/keys/index.js",
+      "require": "./dist/dynamo/keys/index.js"
+    },
+    "./dynamo": {
+      "types": "./dist/dynamo/index.d.ts",
+      "import": "./dist/dynamo/index.js",
+      "require": "./dist/dynamo/index.js"
+    },
+    "./monitoring": {
+      "types": "./dist/monitoring/index.d.ts",
+      "import": "./dist/monitoring/index.js",
+      "require": "./dist/monitoring/index.js"
+    },
+    "./cloudfront": {
+      "types": "./dist/cloudfront/index.d.ts",
+      "import": "./dist/cloudfront/index.js",
+      "require": "./dist/cloudfront/index.js"
+    },
+    "./cloudwatch": {
+      "types": "./dist/cloudwatch/index.d.ts",
+      "import": "./dist/cloudwatch/index.js",
+      "require": "./dist/cloudwatch/index.js"
+    },
+    "./sns": {
+      "types": "./dist/sns/index.d.ts",
+      "import": "./dist/sns/index.js",
+      "require": "./dist/sns/index.js"
+    },
+    "./sqs": {
+      "types": "./dist/sqs/index.d.ts",
+      "import": "./dist/sqs/index.js",
+      "require": "./dist/sqs/index.js"
+    },
+    "./s3": {
+      "types": "./dist/s3/index.d.ts",
+      "import": "./dist/s3/index.js",
+      "require": "./dist/s3/index.js"
+    },
+    "./parameter-store": {
+      "types": "./dist/parameter-store/index.d.ts",
+      "import": "./dist/parameter-store/index.js",
+      "require": "./dist/parameter-store/index.js"
+    },
+    "./lambda": {
+      "types": "./dist/lambda/metrics.d.ts",
+      "import": "./dist/lambda/metrics.js",
+      "require": "./dist/lambda/metrics.js"
+    },
+    "./gateway": {
+      "types": "./dist/gateway/apiGatewayWebsocket.d.ts",
+      "import": "./dist/gateway/apiGatewayWebsocket.js",
+      "require": "./dist/gateway/apiGatewayWebsocket.js"
+    }
+  },
   "files": [
     "dist/**/*.js",
     "dist/**/*.d.ts",
@@ -20,35 +82,116 @@
   "author": "Anton Kropp",
   "license": "MIT",
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.150",
-    "@types/aws4": "^1.11.6",
-    "@types/lodash": "^4.17.18",
-    "@types/nodemailer": "^6.4.17"
-  },
-  "optionalDependencies": {
-    "@paradoxical-io/common-test": "workspace:packages/common-test"
-  },
-  "dependencies": {
-    "@aws-sdk/client-apigatewaymanagementapi": "^3.835.0",
-    "@aws-sdk/client-cloudwatch-logs": "^3.835.0",
-    "@aws-sdk/client-dynamodb": "^3.835.0",
-    "@aws-sdk/client-kms": "^3.835.0",
-    "@aws-sdk/client-s3": "^3.837.0",
-    "@aws-sdk/client-sns": "^3.835.0",
-    "@aws-sdk/client-sqs": "^3.835.0",
-    "@aws-sdk/client-ssm": "^3.835.0",
-    "@aws-sdk/client-sts": "^3.835.0",
-    "@aws-sdk/cloudfront-signer": "^3.821.0",
-    "@aws-sdk/credential-provider-node": "^3.835.0",
-    "@aws-sdk/credential-providers": "^3.835.0",
-    "@aws-sdk/s3-request-presigner": "^3.837.0",
+    "@aws-sdk/client-apigatewaymanagementapi": "^3.1002.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.1002.0",
+    "@aws-sdk/client-dynamodb": "^3.1002.0",
+    "@aws-sdk/client-kms": "^3.1002.0",
+    "@aws-sdk/client-s3": "^3.1002.0",
+    "@aws-sdk/client-sns": "^3.1002.0",
+    "@aws-sdk/client-sqs": "^3.1002.0",
+    "@aws-sdk/client-ssm": "^3.1002.0",
+    "@aws-sdk/client-sts": "^3.1002.0",
+    "@aws-sdk/cloudfront-signer": "^3.1002.0",
+    "@aws-sdk/credential-provider-node": "^3.972.0",
+    "@aws-sdk/credential-providers": "^3.1002.0",
+    "@aws-sdk/s3-request-presigner": "^3.1002.0",
     "@aws-sdk/util-retry": "^3.374.0",
     "@aws/dynamodb-data-mapper": "^0.7.3",
     "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
     "@paradoxical-io/common-server": "workspace:packages/common-server",
-    "@paradoxical-io/types": "workspace:packages/types",
+    "@types/aws-lambda": "^8.10.150",
+    "@types/aws4": "^1.11.6",
+    "@types/lodash": "^4.17.18",
+    "@types/nodemailer": "^6.4.17",
     "aws-lambda": "^1.0.7",
-    "datadog-lambda-js": "^3.59.0",
+    "datadog-lambda-js": "^3.59.0"
+  },
+  "optionalDependencies": {
+    "@paradoxical-io/common-test": "workspace:packages/common-test"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-apigatewaymanagementapi": "^3.1002.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.1002.0",
+    "@aws-sdk/client-dynamodb": "^3.1002.0",
+    "@aws-sdk/client-kms": "^3.1002.0",
+    "@aws-sdk/client-s3": "^3.1002.0",
+    "@aws-sdk/client-sns": "^3.1002.0",
+    "@aws-sdk/client-sqs": "^3.1002.0",
+    "@aws-sdk/client-ssm": "^3.1002.0",
+    "@aws-sdk/client-sts": "^3.1002.0",
+    "@aws-sdk/cloudfront-signer": "^3.1002.0",
+    "@aws-sdk/credential-provider-node": "^3.972.0",
+    "@aws-sdk/credential-providers": "^3.1002.0",
+    "@aws-sdk/s3-request-presigner": "^3.1002.0",
+    "@aws-sdk/util-retry": "^3.374.0",
+    "@aws/dynamodb-data-mapper": "^0.7.3",
+    "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
+    "@paradoxical-io/common-server": "workspace:packages/common-server",
+    "aws-lambda": "^1.0.7",
+    "datadog-lambda-js": "^3.59.0"
+  },
+  "peerDependenciesMeta": {
+    "@aws-sdk/client-apigatewaymanagementapi": {
+      "optional": true
+    },
+    "@aws-sdk/client-cloudwatch-logs": {
+      "optional": true
+    },
+    "@aws-sdk/client-dynamodb": {
+      "optional": true
+    },
+    "@aws-sdk/client-kms": {
+      "optional": true
+    },
+    "@aws-sdk/client-s3": {
+      "optional": true
+    },
+    "@aws-sdk/client-sns": {
+      "optional": true
+    },
+    "@aws-sdk/client-sqs": {
+      "optional": true
+    },
+    "@aws-sdk/client-ssm": {
+      "optional": true
+    },
+    "@aws-sdk/client-sts": {
+      "optional": true
+    },
+    "@aws-sdk/cloudfront-signer": {
+      "optional": true
+    },
+    "@aws-sdk/credential-provider-node": {
+      "optional": true
+    },
+    "@aws-sdk/credential-providers": {
+      "optional": true
+    },
+    "@aws-sdk/s3-request-presigner": {
+      "optional": true
+    },
+    "@aws-sdk/util-retry": {
+      "optional": true
+    },
+    "@aws/dynamodb-data-mapper": {
+      "optional": true
+    },
+    "@aws/dynamodb-data-mapper-annotations": {
+      "optional": true
+    },
+    "@paradoxical-io/common-server": {
+      "optional": true
+    },
+    "aws-lambda": {
+      "optional": true
+    },
+    "datadog-lambda-js": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@paradoxical-io/common": "workspace:packages/common",
+    "@paradoxical-io/types": "workspace:packages/types",
     "joi": "^17.13.3",
     "lodash": "^4.17.21"
   },

--- a/packages/common-aws/src/dynamo/docker.ts
+++ b/packages/common-aws/src/dynamo/docker.ts
@@ -1,43 +1,23 @@
-import { getSchema } from '@aws/dynamodb-data-mapper';
-import { keysFromSchema } from '@aws/dynamodb-data-marshaller';
-import { CreateTableCommand, DynamoDBClient, waitUntilTableExists } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry';
 import { Docker, newDocker } from '@paradoxical-io/common-server/dist/test/docker';
 
 import { DynamoDao } from './mapper';
+import { DynamoUtil } from './util';
 
 export class DynamoDocker {
-  constructor(public container: Docker, public dynamo: DynamoDBClient) {}
+  readonly util: DynamoUtil;
+
+  constructor(public container: Docker, public dynamo: DynamoDBClient) {
+    this.util = new DynamoUtil(dynamo);
+  }
 
   async createTable<T extends DynamoDao>(descriptor: new () => T, tableName?: string): Promise<void> {
-    const schema = getSchema(descriptor.prototype);
-    const { attributes, tableKeys } = keysFromSchema(schema);
+    return this.util.createTable(descriptor, tableName);
+  }
 
-    const attributeDefs = Object.keys(attributes).map(name => ({
-      AttributeName: name,
-      AttributeType: attributes[name],
-    }));
-
-    const keySchema = Object.keys(tableKeys).map(name => ({
-      AttributeName: name,
-      KeyType: tableKeys[name],
-    }));
-
-    const command = new CreateTableCommand({
-      TableName: tableName,
-      AttributeDefinitions: attributeDefs,
-      KeySchema: keySchema,
-      ProvisionedThroughput: {
-        ReadCapacityUnits: 1,
-        WriteCapacityUnits: 1,
-      },
-    });
-
-    const result = await this.dynamo.send(command);
-
-    if (result.TableDescription?.TableStatus !== 'ACTIVE') {
-      await waitUntilTableExists({ client: this.dynamo, maxWaitTime: 30 }, { TableName: tableName });
-    }
+  async removeTable(tableName: string): Promise<void> {
+    return this.util.removeTable(tableName);
   }
 }
 

--- a/packages/common-aws/src/dynamo/docker.ts
+++ b/packages/common-aws/src/dynamo/docker.ts
@@ -34,6 +34,7 @@ export async function newDynamoDocker(): Promise<DynamoDocker> {
   const dynamo = new DynamoDBClient({
     endpoint: base,
     region: 'us-west-2',
+    credentials: { accessKeyId: 'local', secretAccessKey: 'local' },
     // added retry logic as there appears to be intermittent timeout errors with dynamodb-local
     retryStrategy: new ConfiguredRetryStrategy(4, (attempt: number) => 100 + attempt * 1000),
   });

--- a/packages/common-aws/src/dynamo/dynamoLock.ts
+++ b/packages/common-aws/src/dynamo/dynamoLock.ts
@@ -11,7 +11,7 @@ import { EpochSeconds } from '@paradoxical-io/types';
 
 import { Logger, Monitoring, noOpMonitoring } from '../monitoring';
 import { DynamoDao } from './mapper';
-import { DynamoTableName, dynamoTableName } from './util';
+import { DynamoTableName } from './util';
 
 export class DynamoLock implements LockApi {
   private readonly dynamo: DynamoDBClient;
@@ -24,15 +24,15 @@ export class DynamoLock implements LockApi {
 
   constructor({
     dynamo = new DynamoDBClient(),
-    tableName = dynamoTableName('locks'),
+    tableName,
     timeProvider = defaultTimeProvider(),
     monitoring = noOpMonitoring(),
   }: {
     dynamo?: DynamoDBClient;
-    tableName?: DynamoTableName;
+    tableName: DynamoTableName;
     timeProvider?: TimeProvider;
     monitoring?: Monitoring;
-  } = {}) {
+  }) {
     this.dynamo = dynamo;
 
     this.tableName = tableName;

--- a/packages/common-aws/src/dynamo/keys/attempter.ts
+++ b/packages/common-aws/src/dynamo/keys/attempter.ts
@@ -28,10 +28,7 @@ interface AttemptsConfig {
  * A way to handle time/value based attempts
  */
 export class LimitedAttempt {
-  constructor(
-    private reader: PartitionedKeyValueTable = new PartitionedKeyValueTable(),
-    private timeProvider = defaultTimeProvider()
-  ) {}
+  constructor(private reader: PartitionedKeyValueTable, private timeProvider = defaultTimeProvider()) {}
 
   /**
    * Attempts a time expire-able, amount limited action. If the attempt is expired

--- a/packages/common-aws/src/dynamo/keys/index.test.ts
+++ b/packages/common-aws/src/dynamo/keys/index.test.ts
@@ -1,6 +1,0 @@
-import { DynamoTableName } from '../util';
-
-test('dynamo table name type', () => {
-  const name = 'my-table' as DynamoTableName;
-  expect(name).toEqual('my-table');
-});

--- a/packages/common-aws/src/dynamo/keys/index.test.ts
+++ b/packages/common-aws/src/dynamo/keys/index.test.ts
@@ -1,8 +1,6 @@
-import { usingEnv } from '@paradoxical-io/common-test';
+import { DynamoTableName } from '../util';
 
-import { dynamoTableName } from '../util';
-
-test('dynamo names', () =>
-  usingEnv('dev', () => {
-    expect(dynamoTableName('foo')).toEqual('paradox.dev.foo');
-  }));
+test('dynamo table name type', () => {
+  const name = 'my-table' as DynamoTableName;
+  expect(name).toEqual('my-table');
+});

--- a/packages/common-aws/src/dynamo/keys/keyTable.itest.ts
+++ b/packages/common-aws/src/dynamo/keys/keyTable.itest.ts
@@ -2,13 +2,15 @@ import { safeExpect } from '@paradoxical-io/common-test';
 import { CompoundKey, SortKey } from '@paradoxical-io/types';
 
 import { newDynamoDocker } from '../docker';
-import { dynamoTableName, KeyValueCounter, KeyValueCountTableDao } from '../index';
+import { DynamoTableName, KeyValueCounter, KeyValueCountTableDao } from '../index';
 import { KeyValueTable, KeyValueTableDao } from './keyTable';
 import { PartitionedKeyValueTable, PartitionedKeyValueTableDao } from './partitionedKeyTable';
 import { PartitionedKeyCounterTableDao, PartitionedKeyValueCounter } from './partitionedKeyValueCounter';
 
+const testTable = 'test.keys' as DynamoTableName;
+
 test('creates and manages keys', async () => {
-  const table = dynamoTableName('test.keys');
+  const table = testTable;
   const docker = await newDynamoDocker();
   try {
     await docker.createTable(KeyValueTableDao, table);
@@ -35,7 +37,7 @@ test('creates and manages keys', async () => {
 });
 
 test('creates and manages key counters', async () => {
-  const table = dynamoTableName('test.keys');
+  const table = testTable;
   const docker = await newDynamoDocker();
   try {
     await docker.createTable(KeyValueCountTableDao, table);
@@ -68,7 +70,7 @@ test('creates and manages key counters', async () => {
 });
 
 test('creates and manages partitioned key counters', async () => {
-  const table = dynamoTableName('test.keys');
+  const table = testTable;
   const docker = await newDynamoDocker();
   try {
     await docker.createTable(PartitionedKeyCounterTableDao, table);
@@ -102,7 +104,7 @@ test('creates and manages partitioned key counters', async () => {
 });
 
 test('creates and manages partitioned key values', async () => {
-  const table = dynamoTableName('test.keys');
+  const table = testTable;
   const docker = await newDynamoDocker();
   try {
     await docker.createTable(PartitionedKeyValueTableDao, table);
@@ -138,7 +140,7 @@ test('creates and manages partitioned key values', async () => {
 });
 
 test('creates and manages partitioned key sets', async () => {
-  const table = dynamoTableName('test.keys');
+  const table = testTable;
   const docker = await newDynamoDocker();
   try {
     await docker.createTable(PartitionedKeyValueTableDao, table);
@@ -167,7 +169,7 @@ test('creates and manages partitioned key sets', async () => {
 });
 
 test('is parallel safe when for partitioned key sets', async () => {
-  const table = dynamoTableName('test.keys');
+  const table = testTable;
   const docker = await newDynamoDocker();
   try {
     await docker.createTable(PartitionedKeyValueTableDao, table);
@@ -193,7 +195,7 @@ test('is parallel safe when for partitioned key sets', async () => {
 });
 
 test('skips existing data if it exists', async () => {
-  const table = dynamoTableName('test.keys');
+  const table = testTable;
   const docker = await newDynamoDocker();
   try {
     await docker.createTable(PartitionedKeyValueTableDao, table);

--- a/packages/common-aws/src/dynamo/keys/keyTable.ts
+++ b/packages/common-aws/src/dynamo/keys/keyTable.ts
@@ -14,7 +14,7 @@ import { Brand, Milliseconds, notNullOrUndefined } from '@paradoxical-io/types';
 
 import { Logger, Monitoring, noOpMonitoring } from '../../monitoring';
 import { DynamoDao } from '../mapper';
-import { assertTableNameValid, DynamoTableName, dynamoTableName } from '../util';
+import { DynamoTableName } from '../util';
 
 type KeyValueNamespace = Brand<string, 'Namespace'>;
 
@@ -59,16 +59,14 @@ export class KeyValueTable {
   constructor({
     namespace = 'global',
     dynamo = new DynamoDBClient(),
-    tableName = dynamoTableName('keys'),
+    tableName,
     monitoring = noOpMonitoring(),
   }: {
     namespace?: string;
     dynamo?: DynamoDBClient;
-    tableName?: DynamoTableName;
+    tableName: DynamoTableName;
     monitoring?: Monitoring;
-  } = {}) {
-    assertTableNameValid(tableName);
-
+  }) {
     this.namespace = namespace;
 
     this.tableName = tableName;

--- a/packages/common-aws/src/dynamo/keys/keyValueCounter.ts
+++ b/packages/common-aws/src/dynamo/keys/keyValueCounter.ts
@@ -11,7 +11,7 @@ import { Brand, notNullOrUndefined } from '@paradoxical-io/types';
 
 import { Logger, Monitoring, noOpMonitoring } from '../../monitoring';
 import { DynamoDao } from '../mapper';
-import { assertTableNameValid, DynamoTableName, dynamoTableName } from '../util';
+import { DynamoTableName } from '../util';
 
 type KeyValueNamespace = Brand<string, 'Namespace'>;
 
@@ -86,16 +86,14 @@ export class KeyValueCounter {
   constructor({
     namespace,
     dynamo = new DynamoDBClient(),
-    tableName = dynamoTableName('keys'),
+    tableName,
     monitoring = noOpMonitoring(),
   }: {
     namespace: string;
     dynamo?: DynamoDBClient;
-    tableName?: DynamoTableName;
+    tableName: DynamoTableName;
     monitoring?: Monitoring;
   }) {
-    assertTableNameValid(tableName);
-
     this.namespace = namespace;
 
     this.tableName = tableName;

--- a/packages/common-aws/src/dynamo/keys/partitionedKeyTable.ts
+++ b/packages/common-aws/src/dynamo/keys/partitionedKeyTable.ts
@@ -9,14 +9,13 @@ import {
   QueryCommand,
   ResourceNotFoundException,
 } from '@aws-sdk/client-dynamodb';
-import { Arrays, isEqual, jitter, propertyOf, sleep, timed } from '@paradoxical-io/common';
-import { consistentMd5 } from '@paradoxical-io/common-server';
+import { Arrays, consistentMd5, isEqual, jitter, propertyOf, sleep, timed } from '@paradoxical-io/common';
 import { CompoundKey, Milliseconds, notNullOrUndefined, nullOrUndefined, SortKey } from '@paradoxical-io/types';
 import _ from 'lodash';
 
 import { Logger, Metrics, Monitoring, noOpMonitoring } from '../../monitoring';
 import { DynamoDao } from '../mapper';
-import { assertTableNameValid, DynamoTableName, dynamoTableName } from '../util';
+import { DynamoTableName } from '../util';
 import { DynamoKey } from './keyTable';
 
 export class PartitionedKeyValueTableDao<T extends string> implements DynamoDao {
@@ -59,15 +58,13 @@ export class PartitionedKeyValueTable {
 
   constructor({
     dynamo = new DynamoDBClient(),
-    tableName = dynamoTableName('partitioned_keys'),
+    tableName,
     monitoring = noOpMonitoring(),
   }: {
     dynamo?: DynamoDBClient;
-    tableName?: DynamoTableName;
+    tableName: DynamoTableName;
     monitoring?: Monitoring;
-  } = {}) {
-    assertTableNameValid(tableName);
-
+  }) {
     this.tableName = tableName;
 
     this.dynamo = dynamo;

--- a/packages/common-aws/src/dynamo/keys/partitionedKeyValueCounter.ts
+++ b/packages/common-aws/src/dynamo/keys/partitionedKeyValueCounter.ts
@@ -11,7 +11,7 @@ import { CompoundKey, SortKey } from '@paradoxical-io/types';
 
 import { Logger, Monitoring, noOpMonitoring } from '../../monitoring';
 import { DynamoDao } from '../mapper';
-import { assertTableNameValid, DynamoTableName, dynamoTableName } from '../util';
+import { DynamoTableName } from '../util';
 
 export class PartitionedKeyCounterTableDao<T extends string = string> implements DynamoDao {
   @hashKey()
@@ -42,15 +42,13 @@ export class PartitionedKeyValueCounter {
 
   constructor({
     dynamo = new DynamoDBClient(),
-    tableName = dynamoTableName('partitioned_keys'),
+    tableName,
     monitoring = noOpMonitoring(),
   }: {
     dynamo?: DynamoDBClient;
-    tableName?: DynamoTableName;
+    tableName: DynamoTableName;
     monitoring?: Monitoring;
   }) {
-    assertTableNameValid(tableName);
-
     this.tableName = tableName;
 
     this.dynamo = dynamo;

--- a/packages/common-aws/src/dynamo/keys/partitionedKeys.ts
+++ b/packages/common-aws/src/dynamo/keys/partitionedKeys.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { CompoundKey } from '@paradoxical-io/types';
 
-import { DynamoTableName, dynamoTableName } from '../util';
+import { DynamoTableName } from '../util';
 import { PartitionedKeyValueTable } from './partitionedKeyTable';
 import { PartitionedKeyValueCounter } from './partitionedKeyValueCounter';
 
@@ -10,11 +10,11 @@ export class PartitionedKeys {
 
   static default({
     dynamo = new DynamoDBClient(),
-    tableName = dynamoTableName('partitioned_keys'),
+    tableName,
   }: {
     dynamo?: DynamoDBClient;
-    tableName?: DynamoTableName;
-  } = {}) {
+    tableName: DynamoTableName;
+  }) {
     return new PartitionedKeys(
       new PartitionedKeyValueTable({ dynamo, tableName }),
       new PartitionedKeyValueCounter({ dynamo, tableName })

--- a/packages/common-aws/src/dynamo/keys/test/inMemoryKvTable.ts
+++ b/packages/common-aws/src/dynamo/keys/test/inMemoryKvTable.ts
@@ -1,11 +1,14 @@
 import { Streams } from '@paradoxical-io/common';
 import { CompoundKey, notNullOrUndefined } from '@paradoxical-io/types';
 
+import { DynamoTableName } from '../../util';
 import { KeyValueList, KeyValueTable } from '../keyTable';
 import { KeyCount, KeyValueCounter } from '../keyValueCounter';
 import { PartitionedKeys } from '../partitionedKeys';
 import { PartitionedKeyValueTable } from '../partitionedKeyTable';
 import { PartitionedKeyValueCounter } from '../partitionedKeyValueCounter';
+
+const inMemoryTableName = 'in-memory' as DynamoTableName;
 
 /**
  * An in memory kv table that uses a map. Used for testing and stubbing
@@ -15,7 +18,7 @@ export class InMemoryKvTable extends KeyValueTable {
   private readonly store = new Map<string, string>();
 
   constructor() {
-    super({ namespace: '' });
+    super({ namespace: '', tableName: inMemoryTableName });
   }
 
   async delete(id: string): Promise<void> {
@@ -51,7 +54,7 @@ export class InMemoryPartitionedKvTable extends PartitionedKeyValueTable {
   private kvTable: InMemoryKvTable;
 
   constructor() {
-    super({});
+    super({ tableName: inMemoryTableName });
     this.kvTable = new InMemoryKvTable();
   }
 
@@ -121,7 +124,7 @@ export class InMemoryPartitionedKeyCountTable extends PartitionedKeyValueCounter
   private readonly store = new InMemoryPartitionedKvTable();
 
   constructor() {
-    super({});
+    super({ tableName: inMemoryTableName });
   }
 
   async delete<P extends string = string>(id: CompoundKey<P, number>): Promise<void> {
@@ -152,7 +155,7 @@ export class InMemoryKeyCountTable extends KeyValueCounter {
   private readonly store = new Map<string, number>();
 
   constructor() {
-    super({ namespace: '' });
+    super({ namespace: '', tableName: inMemoryTableName });
   }
 
   async delete<K extends string = string>(id: K): Promise<void> {

--- a/packages/common-aws/src/dynamo/util.ts
+++ b/packages/common-aws/src/dynamo/util.ts
@@ -1,22 +1,54 @@
-import { currentEnvironment } from '@paradoxical-io/common-server';
+import { getSchema } from '@aws/dynamodb-data-mapper';
+import { keysFromSchema } from '@aws/dynamodb-data-marshaller';
+import {
+  CreateTableCommand,
+  DeleteTableCommand,
+  DynamoDBClient,
+  waitUntilTableExists,
+  waitUntilTableNotExists,
+} from '@aws-sdk/client-dynamodb';
 import { Brand } from '@paradoxical-io/types';
+
+import { DynamoDao } from './mapper';
 
 export type DynamoTableName = Brand<string, 'DynamoTableName'>;
 
-/**
- * Create a standard dynamo table name in the form of paradox.<env>.<name>
- * @param name the suffix of the name
- */
-export function dynamoTableName(name: string): DynamoTableName {
-  const env = currentEnvironment() === 'local' ? 'dev' : currentEnvironment();
+export class DynamoUtil {
+  constructor(private readonly dynamo: DynamoDBClient) {}
 
-  return `paradox.${env}.${name}` as DynamoTableName;
-}
+  async createTable<T extends DynamoDao>(descriptor: new () => T, tableName?: string): Promise<void> {
+    const schema = getSchema(descriptor.prototype);
+    const { attributes, tableKeys } = keysFromSchema(schema);
 
-export function assertTableNameValid(name: string) {
-  if (currentEnvironment() !== 'local' && !name.includes(`.${currentEnvironment()}.`)) {
-    throw new Error(
-      `Table name must include current environment name in the format of "paradox.<env>.<name>" as a safetynet. Name is ${name}`
-    );
+    const attributeDefs = Object.keys(attributes).map(name => ({
+      AttributeName: name,
+      AttributeType: attributes[name],
+    }));
+
+    const keySchema = Object.keys(tableKeys).map(name => ({
+      AttributeName: name,
+      KeyType: tableKeys[name],
+    }));
+
+    const command = new CreateTableCommand({
+      TableName: tableName,
+      AttributeDefinitions: attributeDefs,
+      KeySchema: keySchema,
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 1,
+        WriteCapacityUnits: 1,
+      },
+    });
+
+    const result = await this.dynamo.send(command);
+
+    if (result.TableDescription?.TableStatus !== 'ACTIVE') {
+      await waitUntilTableExists({ client: this.dynamo, maxWaitTime: 30 }, { TableName: tableName });
+    }
+  }
+
+  async removeTable(tableName: string): Promise<void> {
+    await this.dynamo.send(new DeleteTableCommand({ TableName: tableName }));
+    await waitUntilTableNotExists({ client: this.dynamo, maxWaitTime: 30 }, { TableName: tableName });
   }
 }

--- a/packages/common-aws/src/sns/index.ts
+++ b/packages/common-aws/src/sns/index.ts
@@ -1,0 +1,1 @@
+export * from './sns';

--- a/packages/common-aws/src/sqs/consumer.ts
+++ b/packages/common-aws/src/sqs/consumer.ts
@@ -8,13 +8,12 @@ import {
   SQSClient,
 } from '@aws-sdk/client-sqs';
 import { defaultTimeProvider, sleep, TimeProvider } from '@paradoxical-io/common';
-import { currentEnvironment, isLocal, signals, withNewTrace } from '@paradoxical-io/common-server';
+import { signals, withNewTrace } from '@paradoxical-io/common-server';
 import { bottom, Brand, EpochMS, Milliseconds, notNullOrUndefined, Seconds } from '@paradoxical-io/types';
 
-import { PartitionedKeyValueTable } from '../dynamo';
 import { Logger, Metrics, Monitoring, noOpMonitoring } from '../monitoring';
 import { SQSConfig } from './config';
-import { DevProxyProvider, ProxyQueueProvider } from './proxy/proxyProvider';
+import { ProxyQueueProvider } from './proxy/proxyProvider';
 import { getInvisibilityDelay, SQSEvent } from './publisher';
 
 export type Max10 = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 9 | 10;
@@ -486,11 +485,6 @@ export abstract class SQSConsumer<T> implements MessageProcessor<T> {
   }
 
   private async proxy(messages: Message[] | undefined) {
-    // proxy not allowed in prod or when running local
-    if (currentEnvironment() === 'prod' || isLocal) {
-      return;
-    }
-
     if (!messages) {
       return;
     }
@@ -567,23 +561,23 @@ export class FunctionalConsumerRaw<T> extends SQSConsumer<T> {
 export function newConsumer<T>(
   method: (event: T) => Promise<MessageProcessorResult>,
   config: SQSConfig,
-  monitoring?: Monitoring
+  opts?: { monitoring?: Monitoring; proxyProvider?: ProxyQueueProvider }
 ) {
   return new FunctionalConsumer<T>(method, config.queueUrl, {
     maxNumberOfMessages: config.maxNumberOfMessages,
-    proxyProvider: currentEnvironment() === 'prod' ? undefined : new DevProxyProvider(new PartitionedKeyValueTable()),
-    monitoring,
+    proxyProvider: opts?.proxyProvider,
+    monitoring: opts?.monitoring,
   });
 }
 
 export function newRawConsumer<T>(
   method: (event: SQSEvent<T>) => Promise<MessageProcessorResult>,
   config: SQSConfig,
-  monitoring?: Monitoring
+  opts?: { monitoring?: Monitoring; proxyProvider?: ProxyQueueProvider }
 ) {
   return new FunctionalConsumerRaw<T>(method, config.queueUrl, {
     maxNumberOfMessages: config.maxNumberOfMessages,
-    proxyProvider: currentEnvironment() === 'prod' ? undefined : new DevProxyProvider(new PartitionedKeyValueTable()),
-    monitoring,
+    proxyProvider: opts?.proxyProvider,
+    monitoring: opts?.monitoring,
   });
 }

--- a/packages/common-hapi/package.json
+++ b/packages/common-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paradoxical-io/common-hapi",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "description": "Common hapi code for paradoxical services",
   "files": [
     "dist/**/*.js",

--- a/packages/common-server/package.json
+++ b/packages/common-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paradoxical-io/common-server",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "description": "Common code for paradox services",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/common-server/src/hash/consistent.ts
+++ b/packages/common-server/src/hash/consistent.ts
@@ -1,5 +1,8 @@
-import { chance, deepSort, SafeJson } from '@paradoxical-io/common';
+import { chance } from '@paradoxical-io/common';
 import { createHash } from 'crypto';
+
+// Re-export from common for backwards compatibility
+export { consistentMd5, md5 } from '@paradoxical-io/common';
 
 /**
  * Hashes the value consistently to a space between 0 and 1. Can be used for determining if certain
@@ -33,20 +36,6 @@ export function consistentHashExperimentKey(value: string, key: string): number 
   const hashNum = buffer.readUInt32BE(0);
 
   return consistentHash(value, hashNum);
-}
-
-export function md5(value: string): string {
-  return createHash('md5').update(value).digest().toString('hex');
-}
-
-/**
- * Creates an md5 hash of a deep sorted value, which  means it will be consistent
- * across even when the json fields are arbitrary order.  This is a matter of logical
- * data md5 and not physical json blob md5
- * @param value
- */
-export function consistentMd5(value: unknown): string {
-  return md5(SafeJson.stringify(deepSort(value)));
 }
 
 /**

--- a/packages/common-server/src/logger/log.ts
+++ b/packages/common-server/src/logger/log.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { asMilli, PathRedaction, pruneUndefined, redact, redactKey, SafeJson } from '@paradoxical-io/common';
+import { asMilli, md5, PathRedaction, pruneUndefined, redact, redactKey, SafeJson } from '@paradoxical-io/common';
 import { Brand, notNullOrUndefined } from '@paradoxical-io/types';
 import { LRUCache } from 'lru-cache';
 import { serializeError } from 'serialize-error';
@@ -7,7 +7,6 @@ import * as winston from 'winston';
 import { LoggerOptions } from 'winston';
 
 import { isLocal } from '../env';
-import { md5 } from '../hash';
 import { isAxiosError } from '../http';
 import { Metrics } from '../metrics';
 import { getCurrentUserId, getOptionalContext, Trace, traceID } from '../trace';

--- a/packages/common-sql/package.json
+++ b/packages/common-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paradoxical-io/common-sql",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "files": [
     "dist/**/*.js",
     "dist/**/*.d.ts",

--- a/packages/common-test/package.json
+++ b/packages/common-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paradoxical-io/common-test",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "description": "Common test-code for jest",
   "files": [
     "dist/**/*.js",

--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
           'buffer',
           'child_process',
           'cluster',
-          'crypto',
           'dgram',
           'dns',
           'domain',

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paradoxical-io/common",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "description": "Common code for all paradox projects",
   "files": [
     "dist/**/*.js",

--- a/packages/common/src/hash/consistent.ts
+++ b/packages/common/src/hash/consistent.ts
@@ -1,0 +1,18 @@
+import { createHash } from 'crypto';
+
+import { SafeJson } from '../extensions/object';
+import { deepSort } from '../utils/sortBy';
+
+export function md5(value: string): string {
+  return createHash('md5').update(value).digest().toString('hex');
+}
+
+/**
+ * Creates an md5 hash of a deep sorted value, which  means it will be consistent
+ * across even when the json fields are arbitrary order.  This is a matter of logical
+ * data md5 and not physical json blob md5
+ * @param value
+ */
+export function consistentMd5(value: unknown): string {
+  return md5(SafeJson.stringify(deepSort(value)));
+}

--- a/packages/common/src/hash/index.ts
+++ b/packages/common/src/hash/index.ts
@@ -1,0 +1,1 @@
+export * from './consistent';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,6 +4,7 @@ export * from './decorators';
 export * from './di';
 export * from './errors';
 export * from './extensions';
+export * from './hash';
 export * from './metrics';
 export * from './name';
 export * from './probability';

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paradoxical-io/types",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "description": "Paradox shared types",
   "files": [
     "dist/**/*.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,1094 +97,1069 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-apigatewaymanagementapi@npm:^3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/client-apigatewaymanagementapi@npm:3.835.0"
+"@aws-sdk/client-apigatewaymanagementapi@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/client-apigatewaymanagementapi@npm:3.1017.0"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: 31a9b6ac22fce64576cbf9e7ef02d9fbbf21ab8e5800c082e6691b5bf396d3d10408c1f97807e616096b41b6709def3ab69824bc066fc5f67481f2e5e833258c
+  checksum: d2e166c94cc705d9ff8917c775476424097a54f17f585d323a35d609a724e80707309eb9489a9209ef4e8f3e66526c5580bb0cc839f36066b05c546d4b6203d9
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cloudwatch-logs@npm:^3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.835.0"
+"@aws-sdk/client-cloudwatch-logs@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.1017.0"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/eventstream-serde-browser": ^4.0.4
-    "@smithy/eventstream-serde-config-resolver": ^4.1.2
-    "@smithy/eventstream-serde-node": ^4.0.4
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
-    "@types/uuid": ^9.0.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/eventstream-serde-browser": ^4.2.12
+    "@smithy/eventstream-serde-config-resolver": ^4.3.12
+    "@smithy/eventstream-serde-node": ^4.2.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-    uuid: ^9.0.1
-  checksum: eebfeb0f7b991ab06e57747b1277a4f7f7346d13840d987b1572ffb65869feeb011c1462cf6d0c0b905dabb46303a982b73918fefbec7340855c6c2c33653829
+  checksum: d0bae4c0f2e1e8ec3f3bd5c623f12387d9af1b8aae1e68c541dc007a413e036cb04544778f9de1423350ca9c29d9af0327316f324b5b6ef4148e1b6aeb39424c
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cognito-identity@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/client-cognito-identity@npm:3.835.0"
+"@aws-sdk/client-cognito-identity@npm:3.1017.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/client-cognito-identity@npm:3.1017.0"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: fcf35901a644fe00d9f471edbfd76128a223de9cfc37a66058c75dbde23fe963c53275b17e99e42b3cb9711121e25791109b5fda5a40a2620ab19a0155b0c90f
+  checksum: 324567baae1dc97e7b06af93a411571e3bdf569ddf397fe8b9725307ffad851cd48e5fd7453afa75d36a823ef115c07df1f040e45e0104034f88ac5f249d357d
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-dynamodb@npm:^3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/client-dynamodb@npm:3.835.0"
+"@aws-sdk/client-dynamodb@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/client-dynamodb@npm:3.1017.0"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/middleware-endpoint-discovery": 3.821.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
-    "@smithy/util-waiter": ^4.0.5
-    "@types/uuid": ^9.0.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/dynamodb-codec": ^3.972.25
+    "@aws-sdk/middleware-endpoint-discovery": ^3.972.8
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
+    "@smithy/util-waiter": ^4.2.13
     tslib: ^2.6.2
-    uuid: ^9.0.1
-  checksum: a31e621f293fdc7ca5ea5db54cb97d7bac90c38b81865c3e8b3507aa1cb335fd044458e3d37954f24bd6479201e0cac5579dce392447c9d5ee57c595a6dc5ada
+  checksum: 7e721d2e2956f3431c3b25f7486004bfa0d22550f2101035bbeb585687c07f9265e5903fa4abfd23bbb4fd697d67250103218f4af372dcf6ff76bb8565f59a5c
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-kms@npm:^3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/client-kms@npm:3.835.0"
+"@aws-sdk/client-kms@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/client-kms@npm:3.1017.0"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: 89587b09e0da340bc0504ced3580a2ed3361b46506b74596ca9b44bd0fea2dbd9e7c92f74cf273684b2916cb2f293b8289c6ecfe648ab4a131472b8932d9ada6
+  checksum: d183470ffbd7289a9caa7d2e2eed3233ed2e9a340efca21f115d124596ce0c733a007691b2073423cd59ba3514a1f61191df2e7a3324ca40992dfecd667382bb
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-s3@npm:^3.837.0":
-  version: 3.837.0
-  resolution: "@aws-sdk/client-s3@npm:3.837.0"
+"@aws-sdk/client-s3@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/client-s3@npm:3.1017.0"
   dependencies:
     "@aws-crypto/sha1-browser": 5.2.0
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/middleware-bucket-endpoint": 3.830.0
-    "@aws-sdk/middleware-expect-continue": 3.821.0
-    "@aws-sdk/middleware-flexible-checksums": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-location-constraint": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-sdk-s3": 3.835.0
-    "@aws-sdk/middleware-ssec": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/signature-v4-multi-region": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@aws-sdk/xml-builder": 3.821.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/eventstream-serde-browser": ^4.0.4
-    "@smithy/eventstream-serde-config-resolver": ^4.1.2
-    "@smithy/eventstream-serde-node": ^4.0.4
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-blob-browser": ^4.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/hash-stream-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/md5-js": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-stream": ^4.2.2
-    "@smithy/util-utf8": ^4.0.0
-    "@smithy/util-waiter": ^4.0.5
-    "@types/uuid": ^9.0.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/middleware-bucket-endpoint": ^3.972.8
+    "@aws-sdk/middleware-expect-continue": ^3.972.8
+    "@aws-sdk/middleware-flexible-checksums": ^3.974.4
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-location-constraint": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-sdk-s3": ^3.972.25
+    "@aws-sdk/middleware-ssec": ^3.972.8
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/signature-v4-multi-region": ^3.996.13
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/eventstream-serde-browser": ^4.2.12
+    "@smithy/eventstream-serde-config-resolver": ^4.3.12
+    "@smithy/eventstream-serde-node": ^4.2.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-blob-browser": ^4.2.13
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/hash-stream-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/md5-js": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-stream": ^4.5.20
+    "@smithy/util-utf8": ^4.2.2
+    "@smithy/util-waiter": ^4.2.13
     tslib: ^2.6.2
-    uuid: ^9.0.1
-  checksum: 27f216aa5d0218b37955b9da866d9e8b0dfd286dfdc82d3912f6098c8262e5a787d456194e01af9cb2af0b01db3cb4f5f23348ee569ff5112432912418419c65
+  checksum: 997f1a750cef6ce457e281bc2a4a4f80005759c1b4c02baceaf1334836b7a4daf30ec1a51c072f5d45320a28170649a2edf1229ade643111e6d1c777cbb54ff4
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sns@npm:^3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/client-sns@npm:3.835.0"
+"@aws-sdk/client-sns@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/client-sns@npm:3.1017.0"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: e08be936a21c8614719d1a85e3cc1439becc3186ad58c9ea24aa0377e749dbc2ac0b652ee45e23100df6a347aee6237083ae528d2a993baf4ec7e7df0e045961
+  checksum: 5b4ae0ad77edbc915b84fbfca8edda2f863c78eb7453e36e5bb0c3bf976489df85334fa15def571012f31588fddbff44d2fc3ddd61df000fb4fdbc4c39cb882b
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sqs@npm:^3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/client-sqs@npm:3.835.0"
+"@aws-sdk/client-sqs@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/client-sqs@npm:3.1017.0"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-sdk-sqs": 3.835.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/md5-js": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-sdk-sqs": ^3.972.17
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/md5-js": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: ba065c159fb444c009c1d2da6cc4b73975cb212f618a58a58a36b9fec2cd1d71a8e2de8926f78460cafd34820d0246c81e00578effa5fc646d3be137cedc09bd
+  checksum: f294b1bf1cc772e4621193efdc477bf4b30c8eb5d07cdb55873fa82e540120e6d8d4c740d2f0d5314568d8d9dba4a99324f7f03852294cf23ea4a9601190a082
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-ssm@npm:^3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/client-ssm@npm:3.835.0"
+"@aws-sdk/client-ssm@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/client-ssm@npm:3.1017.0"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
-    "@smithy/util-waiter": ^4.0.5
-    "@types/uuid": ^9.0.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
+    "@smithy/util-waiter": ^4.2.13
     tslib: ^2.6.2
-    uuid: ^9.0.1
-  checksum: d6300ee95d1e5a91eff3f6de6d50efcdaf03465e2107cae65bf859ea41429d8918aa7dfe2ba50faf60baadfd4eae80364015a5c77bd3257b05561c560e079de4
+  checksum: 51a47d30f8af64c80219de7888826bc967d37f7e3ebb9af986be1f501128a51921c9a100a109fb4bda3d713f1171ebd0a06a53877b9a336e3211e77535d1e5d1
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/client-sso@npm:3.835.0"
+"@aws-sdk/client-sts@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/client-sts@npm:3.1017.0"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: dbd25c25df4fcc3d92237e31ac5b91974e289337122947950a048adb4113510a4490c916d06c3af8de5b11ed53b4ba9adf9f48e0710bf50f3eb5a2101ed04c44
+  checksum: 821319a5eb101495a56f2df55d8d2e1588da0f0fe5e465b5cf76513d0a85fe7df5d98860ef5efed7343698a1ef44319b62c7c18615f9991ffabf0b11d20f6dde
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:^3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/client-sts@npm:3.835.0"
+"@aws-sdk/cloudfront-signer@npm:^3.1002.0":
+  version: 3.1012.0
+  resolution: "@aws-sdk/cloudfront-signer@npm:3.1012.0"
   dependencies:
-    "@aws-crypto/sha256-browser": 5.2.0
-    "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
+    "@smithy/core": ^3.23.12
+    "@smithy/url-parser": ^4.2.12
     tslib: ^2.6.2
-  checksum: 95dea53a27a04e4d64af93702a4441a023dfec89659a5632265653ea975f2ab16c58b9a409b061c7aa13860d63946652fa37d918d9b7e9f7eedc4d2e83c2d8a1
+  checksum: 37ea431e2bce2ebe56c62707cd6c2488e630b6d798d307e3f151612e2d42e6f3ed9b18405ef163b806d1abc8c19ee69c1f0f5fcb82b274d5f1dc5ff655d32ee2
   languageName: node
   linkType: hard
 
-"@aws-sdk/cloudfront-signer@npm:^3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/cloudfront-signer@npm:3.821.0"
+"@aws-sdk/core@npm:^3.973.24":
+  version: 3.973.24
+  resolution: "@aws-sdk/core@npm:3.973.24"
   dependencies:
-    "@smithy/url-parser": ^4.0.4
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/xml-builder": ^3.972.15
+    "@smithy/core": ^3.23.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/signature-v4": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: 03a6b7500596d13e480527a7ff598bed0e7d8afb2ea8441bdb1127d3a5683bbaf145e68a21c790b957fe9fe7ecc1fa328b60b12d1147caac873bccd9a43b9d7a
+  checksum: a5124f258c375e9a0b16ffd19df443b75a4bd58ea7a6b405c6957b78ef20ed77026328734cbd99f6ae23199bc35831d78a621fe3b77e79096041a42c6beeb922
   languageName: node
   linkType: hard
 
-"@aws-sdk/core@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/core@npm:3.835.0"
+"@aws-sdk/crc64-nvme@npm:^3.972.5":
+  version: 3.972.5
+  resolution: "@aws-sdk/crc64-nvme@npm:3.972.5"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/xml-builder": 3.821.0
-    "@smithy/core": ^3.5.3
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/signature-v4": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-utf8": ^4.0.0
-    fast-xml-parser: 4.4.1
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 14ef2d9b72029eff21994ba1f5ad401345b7d0dc23ecb9527c03dba5bb8209ab0a6f1e8f7fab710dbd606b50f9829364b85dfdeeb22723111a782144b1722718
+  checksum: afa609029896e653bc2cb8c8529a1faf595bfbf99a73a5584a7900ffe92e797266eaf16204ddd2e0be21455c8711122966cb4fb13012c9e36accaa133c3b76db
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-cognito-identity@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.835.0"
+"@aws-sdk/credential-provider-cognito-identity@npm:^3.972.17":
+  version: 3.972.17
+  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.972.17"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/nested-clients": ^3.996.14
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: c49491da63e0f158e3761511db05ca82064b65eb5f9db861f692d16863c962a4e7a4cabab1d8c5c86313697a635d7fd1817a2ca7a3ca7c0bcb8d20ec2d8b8778
+  checksum: afcf61d2f9a1cfb2d4dd8dcf08a5e3c0e05bd87be1edd8adeca17ff08427b14431e67aa455f1f9b4c5414bd397816cc63aab67ce6599a54bc30124ded80344e9
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.835.0"
+"@aws-sdk/credential-provider-env@npm:^3.972.22":
+  version: 3.972.22
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.22"
   dependencies:
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 24def8ee383c7d45cc532c0144681f54c5fa3a43f4f672bef2fec96e5b654b3c407dc7fee4151e55129fbd8fadd1710e1440bd4e2c92ed825fd04faed9bdf0bc
+  checksum: 12f7ea3e83a634189dfdce1c93ae6c194733df558f5b1e728ba1b62554b38312e0c876f502f3b3af8b010f23c70b8186b80519cbbbadc6fa0b1087b246e4f490
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-http@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/credential-provider-http@npm:3.835.0"
+"@aws-sdk/credential-provider-http@npm:^3.972.24":
+  version: 3.972.24
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.24"
   dependencies:
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/util-stream": ^4.2.2
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/util-stream": ^4.5.20
     tslib: ^2.6.2
-  checksum: cca02181baf164d57eab8b4bfe483d6f59fb2f013ec0107f21fea5370a97b3bb9f13230b56de346fba3d965e763dbf3cc5301ab2048fb78caa464e5b80a55b43
+  checksum: b23505620f9bc611622a36d0861e894d30839b549a3f00fd338582a2dd43a58a0bed0880988ec70663766f7972fa29b0588c64904c2541e3d5773cb06cde7e0b
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.835.0"
+"@aws-sdk/credential-provider-ini@npm:^3.972.24":
+  version: 3.972.24
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.972.24"
   dependencies:
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-env": 3.835.0
-    "@aws-sdk/credential-provider-http": 3.835.0
-    "@aws-sdk/credential-provider-process": 3.835.0
-    "@aws-sdk/credential-provider-sso": 3.835.0
-    "@aws-sdk/credential-provider-web-identity": 3.835.0
-    "@aws-sdk/nested-clients": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/credential-provider-imds": ^4.0.6
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/shared-ini-file-loader": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-env": ^3.972.22
+    "@aws-sdk/credential-provider-http": ^3.972.24
+    "@aws-sdk/credential-provider-login": ^3.972.24
+    "@aws-sdk/credential-provider-process": ^3.972.22
+    "@aws-sdk/credential-provider-sso": ^3.972.24
+    "@aws-sdk/credential-provider-web-identity": ^3.972.24
+    "@aws-sdk/nested-clients": ^3.996.14
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/credential-provider-imds": ^4.2.12
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/shared-ini-file-loader": ^4.4.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: a0ca1d785444433bada7a15df26b0db47341492f4da4710d61dbb2e2c30fb6fa6f440ee909844ea8d083374c119819c0dc60b6eb38da343b6ec5905d13b3bb48
+  checksum: 35ea34081bf94d93101469e030ec3114d45eb7b6a60066dcd26c060d0122fd2f914524b35e9346888d82fa1080aef91a6c64618b4e47b1a3a13fd36f2fa4264c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.835.0, @aws-sdk/credential-provider-node@npm:^3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.835.0"
+"@aws-sdk/credential-provider-login@npm:^3.972.24":
+  version: 3.972.24
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.24"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.835.0
-    "@aws-sdk/credential-provider-http": 3.835.0
-    "@aws-sdk/credential-provider-ini": 3.835.0
-    "@aws-sdk/credential-provider-process": 3.835.0
-    "@aws-sdk/credential-provider-sso": 3.835.0
-    "@aws-sdk/credential-provider-web-identity": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/credential-provider-imds": ^4.0.6
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/shared-ini-file-loader": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/nested-clients": ^3.996.14
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/shared-ini-file-loader": ^4.4.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 0b611d9d47b4b380b9552780dfcc094f9d6bd00d2ec8a45dcb9b74883cc31509a3fc5f8cec9347859375cca1c6b2cfbbfc1c3e0227af809c451622d4dba9c8f1
+  checksum: ecebc97348b6a65cf09080e2efb4e53442ee339f2a7dd4e88ae645ed1163448d9913f358fa917fa7b7374a46593c20e232fbfaaf5386551eb7aa5bb7d6321055
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.835.0"
+"@aws-sdk/credential-provider-node@npm:^3.972.0, @aws-sdk/credential-provider-node@npm:^3.972.25":
+  version: 3.972.25
+  resolution: "@aws-sdk/credential-provider-node@npm:3.972.25"
   dependencies:
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/shared-ini-file-loader": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/credential-provider-env": ^3.972.22
+    "@aws-sdk/credential-provider-http": ^3.972.24
+    "@aws-sdk/credential-provider-ini": ^3.972.24
+    "@aws-sdk/credential-provider-process": ^3.972.22
+    "@aws-sdk/credential-provider-sso": ^3.972.24
+    "@aws-sdk/credential-provider-web-identity": ^3.972.24
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/credential-provider-imds": ^4.2.12
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/shared-ini-file-loader": ^4.4.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 85def4cac21326988b8975bf30aff9bc13636ef1d6300e5f339fec20c127854afee0e057198d71e13271c359e10b04144a129704200c706ec2a7dbfbace8c31e
+  checksum: 74cd7c8f0caa82c17a91a9327538bed93b5d1259f3259e4118e85f03ed53acc4a314f97ec8ced23e502cec2bc1e8960f0a4e749cdeb9846f326e3ad216d1a796
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.835.0"
+"@aws-sdk/credential-provider-process@npm:^3.972.22":
+  version: 3.972.22
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.22"
   dependencies:
-    "@aws-sdk/client-sso": 3.835.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/token-providers": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/shared-ini-file-loader": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/shared-ini-file-loader": ^4.4.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: d171d3297249357a80c7b7e66f22c08e8bfabf0a3d10a98201da5170dc497d1fb3f5d4af6608afd1af2746fdbc6321b66a77a1aeaf3a17950ef6a67ccf2098bf
+  checksum: f03b22c8ff7059ca72b6603df535afc7066a143ff79f057266bc7f186c986260ef2ae40784e03dd5e4cf05df424010695362194a3db6ac360e5c251ead641a9c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.835.0"
+"@aws-sdk/credential-provider-sso@npm:^3.972.24":
+  version: 3.972.24
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.972.24"
   dependencies:
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/nested-clients": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/nested-clients": ^3.996.14
+    "@aws-sdk/token-providers": 3.1015.0
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/shared-ini-file-loader": ^4.4.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 5ed11aad357cd678030a7611d3d0cacd412f0a17d0fde300d1ecd7cbe7e7ba3d9b40d454f975490a5c7e200ae0cf01ff0528b39ee7520adb1e5b0010f6f3c752
+  checksum: 781a7a75d3c6256c190765db9abf27031948005450486092e66248e179052fc62f84e64c59d8da52df107017c5f5e2dae17600d5a71f6a4c5ed70d069acaaf3a
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-providers@npm:^3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/credential-providers@npm:3.835.0"
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.24":
+  version: 3.972.24
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.24"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.835.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/credential-provider-cognito-identity": 3.835.0
-    "@aws-sdk/credential-provider-env": 3.835.0
-    "@aws-sdk/credential-provider-http": 3.835.0
-    "@aws-sdk/credential-provider-ini": 3.835.0
-    "@aws-sdk/credential-provider-node": 3.835.0
-    "@aws-sdk/credential-provider-process": 3.835.0
-    "@aws-sdk/credential-provider-sso": 3.835.0
-    "@aws-sdk/credential-provider-web-identity": 3.835.0
-    "@aws-sdk/nested-clients": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/credential-provider-imds": ^4.0.6
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/nested-clients": ^3.996.14
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/shared-ini-file-loader": ^4.4.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 12b8c37ab7e9e496d6ed803b3b8f11cbcc3c90028176374e7c6f9dd7eb1b68f8497fba558d5e7f1bafd094a0729fb298699bf37d4aa769f877abd5dff7b079b4
+  checksum: 3ad8afb0c5931de4229b1c2633e7265e39530d561466ae858bba431786d74161026c8e16b65990df706876663c7de20acb8a98db22d37ea9071926e35568004b
   languageName: node
   linkType: hard
 
-"@aws-sdk/endpoint-cache@npm:3.804.0":
-  version: 3.804.0
-  resolution: "@aws-sdk/endpoint-cache@npm:3.804.0"
+"@aws-sdk/credential-providers@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/credential-providers@npm:3.1017.0"
+  dependencies:
+    "@aws-sdk/client-cognito-identity": 3.1017.0
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/credential-provider-cognito-identity": ^3.972.17
+    "@aws-sdk/credential-provider-env": ^3.972.22
+    "@aws-sdk/credential-provider-http": ^3.972.24
+    "@aws-sdk/credential-provider-ini": ^3.972.24
+    "@aws-sdk/credential-provider-login": ^3.972.24
+    "@aws-sdk/credential-provider-node": ^3.972.25
+    "@aws-sdk/credential-provider-process": ^3.972.22
+    "@aws-sdk/credential-provider-sso": ^3.972.24
+    "@aws-sdk/credential-provider-web-identity": ^3.972.24
+    "@aws-sdk/nested-clients": ^3.996.14
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/credential-provider-imds": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/types": ^4.13.1
+    tslib: ^2.6.2
+  checksum: 744278bd3950f175377980d1e86fd9750f4d20881e6b1b3b629ec55d34268db7b873612f15fb4231776216c8cd7dc1fd1e4b9dab049075d33f4a310165f6ddcb
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/dynamodb-codec@npm:^3.972.25":
+  version: 3.972.25
+  resolution: "@aws-sdk/dynamodb-codec@npm:3.972.25"
+  dependencies:
+    "@aws-sdk/core": ^3.973.24
+    "@smithy/core": ^3.23.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/util-base64": ^4.3.2
+    tslib: ^2.6.2
+  checksum: 969f238fbf41da111915833f3fba5065b38179ce4204e548e98583bdc942ac8d4c93c821c05c3d098532fb0771c8cfc3812f2e5b961417854a7494e2b56ce5f8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/endpoint-cache@npm:^3.972.4":
+  version: 3.972.4
+  resolution: "@aws-sdk/endpoint-cache@npm:3.972.4"
   dependencies:
     mnemonist: 0.38.3
     tslib: ^2.6.2
-  checksum: 3f1d47ac411d8e58b045bf7d61be821e59c08464fd507ee17388f7d6ce202aca8bdae314b30e9df046f9ed4de87e1100666e9b47a7bcbbe187ddfcc38b57ba13
+  checksum: 05f7cdfb3e56eff8b778552318671ba52acbb77f66fcbde1b90baa3605d52dbd72fe56858d9c7866fc16f8ab536edb3121266487b0c11bacd4c32c1cc6a8cf31
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-bucket-endpoint@npm:3.830.0":
-  version: 3.830.0
-  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.830.0"
+"@aws-sdk/middleware-bucket-endpoint@npm:^3.972.8":
+  version: 3.972.8
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.972.8"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-arn-parser": 3.804.0
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
-    "@smithy/util-config-provider": ^4.0.0
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-arn-parser": ^3.972.3
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
+    "@smithy/util-config-provider": ^4.2.2
     tslib: ^2.6.2
-  checksum: 59709b2d82aa12ee6e5f5fb442f22363bf647a51d9e9c049b452fe5767f9e773670de6f3a6a9e70e5c76d024db09b5751ade19501ca519264e999c92471a7295
+  checksum: b9ef658721f87a29a5163126ebd3eb54928c291c16920690c541bb02ac350965cea7a26f9d8e7e7c61c0abe0a9a7b0f1e3d1a439e77329d269635d5170fcb318
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-endpoint-discovery@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/middleware-endpoint-discovery@npm:3.821.0"
+"@aws-sdk/middleware-endpoint-discovery@npm:^3.972.8":
+  version: 3.972.8
+  resolution: "@aws-sdk/middleware-endpoint-discovery@npm:3.972.8"
   dependencies:
-    "@aws-sdk/endpoint-cache": 3.804.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/endpoint-cache": ^3.972.4
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: c66f5e03186cc63d1a798d8f532bee40edfdde76142722f605408d8c023992461fe51c427551c3eb24cd27b2e77945c1ea32491559c30449730cbe45182dd127
+  checksum: 8ca38a2b7136a508b459c45bd274c6cd56cfa42b2f0456853b052beb98be16523fcea2afd9af8cbba28c157182038fb4e43389596f3313cf97bcc36444147467
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-expect-continue@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/middleware-expect-continue@npm:3.821.0"
+"@aws-sdk/middleware-expect-continue@npm:^3.972.8":
+  version: 3.972.8
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.972.8"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 491630158cecd4226c4dad1f33420bc391892925f8a08fbfcca22d4c7178276641996ceaa441988145a182ad833d4bc05cf7511c74fb46259b49fe8a97dce1f8
+  checksum: b0397698047bae51f98191b04efb35e2e1f73af4ba69621432cef8bb4c2000487aa27cebaf3754be75a801a3c59f5169f1956b2de58ed6ab55a724edcd0dd47f
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-flexible-checksums@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.835.0"
+"@aws-sdk/middleware-flexible-checksums@npm:^3.974.4":
+  version: 3.974.4
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.974.4"
   dependencies:
     "@aws-crypto/crc32": 5.2.0
     "@aws-crypto/crc32c": 5.2.0
     "@aws-crypto/util": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/is-array-buffer": ^4.0.0
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-stream": ^4.2.2
-    "@smithy/util-utf8": ^4.0.0
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/crc64-nvme": ^3.972.5
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/is-array-buffer": ^4.2.2
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-stream": ^4.5.20
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: aaa499453ed660e1135f7f833b524d00a7fc76c90b96cff52c244eca328b7a36290c60c666cf6a18f3acbfcd7cde45420491602cf1521eebe79030ce78f5a0bf
+  checksum: 94b4828414f40817129edaae612e50c05dc0efb2e325f0864a30720f5fc2e3f7abb8213cf3684c1cecb6906eb54e8b10703dac40f1e45ead305d4c083e520edd
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.821.0"
+"@aws-sdk/middleware-host-header@npm:^3.972.8":
+  version: 3.972.8
+  resolution: "@aws-sdk/middleware-host-header@npm:3.972.8"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: b626412b0ccb169542311230d0c16e62c21179802e2d6041b5305b3da02de7c3ea352c892162d416ab0fc92e6cc5fbfbf14671b0dd0c54a36cf33efa91a7fd1e
+  checksum: 05f4868c556493c7dd3da3fa41ccf739ee1fa7520a2a8ed67a70319e96a2ea9ad8a2cc239e5f7bc4916aa34ed9df91148ccf0aa9b6738915426a1c68f33ef2d3
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-location-constraint@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/middleware-location-constraint@npm:3.821.0"
+"@aws-sdk/middleware-location-constraint@npm:^3.972.8":
+  version: 3.972.8
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.972.8"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 825919c9fd005990ef52506b9069f2ce8e947a3429105e7edd8f19e0fdfe3f9304824ab8e4a962f55c9baddbd668bc257fae60deb833e76be2805b4873b65084
+  checksum: 3395701874e56c4cf161b94e70c101ec6fc41de32ce223d8dd187e47e17efaa1058df9c18982ffd4eabaac12021d2f1bc83d4d771a0f448e50ea7673e2864648
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.821.0"
+"@aws-sdk/middleware-logger@npm:^3.972.8":
+  version: 3.972.8
+  resolution: "@aws-sdk/middleware-logger@npm:3.972.8"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 1f287c7a9a1cff4413070ff84459c41102dcf063b8cbc90efb67e8ab23beebd9c3814c7e2d59166027520d8f91aaaee39ab66aa53bae129327e509b95ab24085
+  checksum: 5067f3b6c674ea52e594d144db517ed203c213a9acd5a816b27e7c04301965ce920388b2ea8e16b35d9d0c064d01774a0c600815a8c4e6a2e590da0600b8cc9e
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-recursion-detection@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.821.0"
+"@aws-sdk/middleware-recursion-detection@npm:^3.972.8":
+  version: 3.972.8
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.972.8"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/types": ^3.973.6
+    "@aws/lambda-invoke-store": ^0.2.2
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 8abb4c2df2c30507b12d6e002f7d99cac09309b350f07094e4b540b3036dd1d2b073b79882fc6819b15f50837e40e5f05a3bd8547964a7a146a210355d39a85f
+  checksum: 38e9af1730583be5fe9ff088c61e5bf641fdbb49a8f2a9cae47e968d29aa52f6717e9e2b901f938ffa12f03cad2166d6a22267f161b9dfd598718a7d6c0a1bb7
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.835.0"
+"@aws-sdk/middleware-sdk-s3@npm:^3.972.25":
+  version: 3.972.25
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.972.25"
   dependencies:
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-arn-parser": 3.804.0
-    "@smithy/core": ^3.5.3
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/signature-v4": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/util-config-provider": ^4.0.0
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-stream": ^4.2.2
-    "@smithy/util-utf8": ^4.0.0
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-arn-parser": ^3.972.3
+    "@smithy/core": ^3.23.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/signature-v4": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/util-config-provider": ^4.2.2
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-stream": ^4.5.20
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: 0c0965d5cba1a1f65a4c7c87a519e3e9ebda9f695af6926f6d1c2165af3056d1ee53b0327daa8e04bc600fe6d05bf65c038b13231001d2a82c9e2ddec26ff1ad
+  checksum: dc6db6897eab79640cd7688f23006039eeef31f8e3c02a54867605cfde7a686ce15ed535158a81153416af55b035fc2fed45d2033db197154aaf0f61f43e6a83
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sqs@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/middleware-sdk-sqs@npm:3.835.0"
+"@aws-sdk/middleware-sdk-sqs@npm:^3.972.17":
+  version: 3.972.17
+  resolution: "@aws-sdk/middleware-sdk-sqs@npm:3.972.17"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/util-hex-encoding": ^4.0.0
-    "@smithy/util-utf8": ^4.0.0
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/util-hex-encoding": ^4.2.2
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: 06fe678c33d8ba0ab225bfe9fa0f9b0835e908b0e5497a4ce1af16c587e5c90a4576e243127b9943a839cebaf6f4f89fc0952f23398851309a02d8c00f29b120
+  checksum: 17aff9c8e846a7a256f1ee8bcaf34d43b13610b0fd9b2fe3c303352ae5096aa61d82fe04ff99b8d4d9236471ab138000f321959b079ba64ea0c92efbf7bd0c23
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-ssec@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/middleware-ssec@npm:3.821.0"
+"@aws-sdk/middleware-ssec@npm:^3.972.8":
+  version: 3.972.8
+  resolution: "@aws-sdk/middleware-ssec@npm:3.972.8"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: edec7047f1971a62ca6e069b7d072aa9fc12471d4bcd4b2d68b2392d30f2b85c8af58b28b54ca6bc91dfd3ddf6a3c25cd82cb252a8d6f417de3a9225552558c5
+  checksum: 8d184ab93032bc04d402958dff6a1af25c154ff52baff4de9edb0e2b46206ab47a0f96516d850a0090fa1ba79c20eabfff68106fe77a84a2467a3afc105e3dbb
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.835.0"
+"@aws-sdk/middleware-user-agent@npm:^3.972.25":
+  version: 3.972.25
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.972.25"
   dependencies:
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@smithy/core": ^3.5.3
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@smithy/core": ^3.23.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
+    "@smithy/util-retry": ^4.2.12
     tslib: ^2.6.2
-  checksum: c29160d0963a2c350e6ebd6731e5433f04caf043676e3ea435ccf4418b6605ee7ae83aaf49188fdbb6f3afe15f8ce0e2ea51fbf477237e233e8fcd3d1ea51469
+  checksum: 6180b911a1a8bbfcf1adf074f3c153bf058b73a987ba88e38583b845ac48343f3ab2218a5a3af58fc964156f3452c01205aeb21b6398794956efad74ec324465
   languageName: node
   linkType: hard
 
-"@aws-sdk/nested-clients@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/nested-clients@npm:3.835.0"
+"@aws-sdk/nested-clients@npm:^3.996.14":
+  version: 3.996.14
+  resolution: "@aws-sdk/nested-clients@npm:3.996.14"
   dependencies:
     "@aws-crypto/sha256-browser": 5.2.0
     "@aws-crypto/sha256-js": 5.2.0
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/middleware-host-header": 3.821.0
-    "@aws-sdk/middleware-logger": 3.821.0
-    "@aws-sdk/middleware-recursion-detection": 3.821.0
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/region-config-resolver": 3.821.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-endpoints": 3.828.0
-    "@aws-sdk/util-user-agent-browser": 3.821.0
-    "@aws-sdk/util-user-agent-node": 3.835.0
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/core": ^3.5.3
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/hash-node": ^4.0.4
-    "@smithy/invalid-dependency": ^4.0.4
-    "@smithy/middleware-content-length": ^4.0.4
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/middleware-retry": ^4.1.13
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-body-length-node": ^4.0.0
-    "@smithy/util-defaults-mode-browser": ^4.0.20
-    "@smithy/util-defaults-mode-node": ^4.0.20
-    "@smithy/util-endpoints": ^3.0.6
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
-    "@smithy/util-utf8": ^4.0.0
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/middleware-host-header": ^3.972.8
+    "@aws-sdk/middleware-logger": ^3.972.8
+    "@aws-sdk/middleware-recursion-detection": ^3.972.8
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/region-config-resolver": ^3.972.9
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-endpoints": ^3.996.5
+    "@aws-sdk/util-user-agent-browser": ^3.972.8
+    "@aws-sdk/util-user-agent-node": ^3.973.11
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/core": ^3.23.12
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/hash-node": ^4.2.12
+    "@smithy/invalid-dependency": ^4.2.12
+    "@smithy/middleware-content-length": ^4.2.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-retry": ^4.4.44
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-body-length-node": ^4.2.3
+    "@smithy/util-defaults-mode-browser": ^4.3.43
+    "@smithy/util-defaults-mode-node": ^4.2.47
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: 470ba33d7731d623e492b3883b0ea115f68742c966fb1cb5361b3b25fd694d11d85de86ce55a7a777a12f3c85535b498ecd54436b729c1c11fa0b6afef82a65e
+  checksum: e90a74120b5909795fec9c4ac9603dc202e3d4898560a37f77f80aac44d360b8f160fff0f8bbf7fe504c3ca9dfad606c432d62b475a5c49645d3dd717c2ce70c
   languageName: node
   linkType: hard
 
-"@aws-sdk/region-config-resolver@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/region-config-resolver@npm:3.821.0"
+"@aws-sdk/region-config-resolver@npm:^3.972.9":
+  version: 3.972.9
+  resolution: "@aws-sdk/region-config-resolver@npm:3.972.9"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/types": ^4.3.1
-    "@smithy/util-config-provider": ^4.0.0
-    "@smithy/util-middleware": ^4.0.4
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: e3688c64180308ef3db8347b13402f5d261d9d033c9c7e912746630c519d30f123e8a89cac87fc0314e798aa2edacf0a01d6fb901a14ca0e3d179058959dcc2f
+  checksum: aec1b98aa05e304fde2c20ba5827ad2f9c7f50968791676bae00d271f7a078ddcc8b7a6891fe38e0d6858398186f71a61420b18c97e79cae645482d3a2bc1dde
   languageName: node
   linkType: hard
 
-"@aws-sdk/s3-request-presigner@npm:^3.837.0":
-  version: 3.837.0
-  resolution: "@aws-sdk/s3-request-presigner@npm:3.837.0"
+"@aws-sdk/s3-request-presigner@npm:^3.1002.0":
+  version: 3.1017.0
+  resolution: "@aws-sdk/s3-request-presigner@npm:3.1017.0"
   dependencies:
-    "@aws-sdk/signature-v4-multi-region": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@aws-sdk/util-format-url": 3.821.0
-    "@smithy/middleware-endpoint": ^4.1.12
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/smithy-client": ^4.4.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/signature-v4-multi-region": ^3.996.13
+    "@aws-sdk/types": ^3.973.6
+    "@aws-sdk/util-format-url": ^3.972.8
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 9875197503c5a4bb7dae0011ec1bd120457100cb9af25cda40841d8160203fe511d79e65434b77b960e7249dbc208990f6087b5b8841b1a165b5994dcbb24b96
+  checksum: 7acfb6235539b0c5353c132738e9ebea86af273bbaad8a224fa3fbd6518bb37aab2564cbdbeab7c8d5fdd5dcd5108076dfecc95994df9ec99b5fcc7b04ebb0d0
   languageName: node
   linkType: hard
 
-"@aws-sdk/service-error-classification@npm:^3.4.1":
-  version: 3.347.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.347.0"
-  checksum: 5404b520a41ddddf54f48f391b27c551232358ed059ba8f02c818b57d7cc5b96156e3a4466f08435fca181ba645e97ad487d771b30dd13024ca0c2e3fd06cfaa
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/signature-v4-multi-region@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.835.0"
+"@aws-sdk/signature-v4-multi-region@npm:^3.996.13":
+  version: 3.996.13
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.13"
   dependencies:
-    "@aws-sdk/middleware-sdk-s3": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/signature-v4": ^5.1.2
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/middleware-sdk-s3": ^3.972.25
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/signature-v4": ^5.3.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: e6c2bd7876597bef70dc342251ae87bb0481b0f43699ab172560c72b73ea9fd01668e7143d592b23d3b3f9a42b8b3dc20f97bfef8ea61e6e0d7ba2275a3e974f
+  checksum: 28141adc9afcaa964247520f8b020760483f9147c645102399f1e359ed30b234b331d4b13d8295f5fa7af22ad11427115f1f59b1efedcc7c554051c1cf023cfe
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/token-providers@npm:3.835.0"
+"@aws-sdk/token-providers@npm:3.1015.0":
+  version: 3.1015.0
+  resolution: "@aws-sdk/token-providers@npm:3.1015.0"
   dependencies:
-    "@aws-sdk/core": 3.835.0
-    "@aws-sdk/nested-clients": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/shared-ini-file-loader": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/core": ^3.973.24
+    "@aws-sdk/nested-clients": ^3.996.14
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/shared-ini-file-loader": ^4.4.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 1800f652d22e086b97c69525284c19122fd77fa0bdececc5a68a183787ae60be1e2b23be0fe8fb9f2860bd7527ac5cf8043e143401b0d39b16a319a33934ceec
+  checksum: e7c5759be23101df8b9f2c024722152f5ec972d9acc11565fd32ce177ee989d5dba10b895da514a8370cddd230320d77694ed7329bde9b5ccc2d367b25d864a4
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.821.0, @aws-sdk/types@npm:^3.222.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/types@npm:3.821.0"
+"@aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.4.1, @aws-sdk/types@npm:^3.973.6":
+  version: 3.973.6
+  resolution: "@aws-sdk/types@npm:3.973.6"
   dependencies:
-    "@smithy/types": ^4.3.1
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 999e0344b0eea74b5d423b9cc562ae6b00c5c1e3fb7d1f6f86e81cbdb0dfa948cc574cc5ab4e9e875043d559904128807f3e95119b97123a8cc37dd5471f6c35
+  checksum: 3d4a830db4c9281a0ea4be1fa21b8359cb0ab7ba6092ad4eb766f2946c54d2dc03cf5c3127ae498dc33b73dbfe6da5cdd9292f36c869345a90f5fc020e4e1c69
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:^3.4.1":
-  version: 3.347.0
-  resolution: "@aws-sdk/types@npm:3.347.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 799b053d3651f1754e2925b671fe890047d0ff1af69d22b6826d8e74edefcd558c7c7a911d48eaf5930032bcf291dbdbb6dd2d2f0c596bbe52100941aa349221
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-arn-parser@npm:3.804.0":
-  version: 3.804.0
-  resolution: "@aws-sdk/util-arn-parser@npm:3.804.0"
+"@aws-sdk/util-arn-parser@npm:^3.972.3":
+  version: 3.972.3
+  resolution: "@aws-sdk/util-arn-parser@npm:3.972.3"
   dependencies:
     tslib: ^2.6.2
-  checksum: ac3218111ddc24ee048972f9c164029d7ffe57e50e8c720594b9f74547840a1c0eb7dcf82fa61b15a4997acbed6b64e02affdec6f731c386529150ec5a97e3e6
+  checksum: 1d80305add2a8c342b8084abed6a2ba463f26a9e72a2baafd4334f302a47be7cb6b82e6cfd5a28f4f3b2eade16dc27e8765de79fae0f54a1154e6edc5193b4d4
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-endpoints@npm:3.828.0":
-  version: 3.828.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.828.0"
+"@aws-sdk/util-endpoints@npm:^3.996.5":
+  version: 3.996.5
+  resolution: "@aws-sdk/util-endpoints@npm:3.996.5"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/types": ^4.3.1
-    "@smithy/util-endpoints": ^3.0.6
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-endpoints": ^3.3.3
     tslib: ^2.6.2
-  checksum: 0d914554b517f9ad4828ea09abece8fbf99c0c10f833b9973b373b89d2d7f21c50f01315512f56d71bf6e23a11993a6c02eef90af8e3dfb66d28cbf4039446b0
+  checksum: c9cb0553498cdc264ffcb2a5f757ffb56cdc70afea2dbf3e4d9331581e5a9ca07b3818d809ea1731542604c5a2a5511645acb4e0bab8baf03f36bc31edcacbc2
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-format-url@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/util-format-url@npm:3.821.0"
+"@aws-sdk/util-format-url@npm:^3.972.8":
+  version: 3.972.8
+  resolution: "@aws-sdk/util-format-url@npm:3.972.8"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/querystring-builder": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/querystring-builder": ^4.2.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 22294218a8bfd6ddc13a0cedd8fca3e0178758676bdca318c0f29abb53094edb8d3e3966addc8b62df87d4050530072b3a8129dce8b91ea2f96dfa6ec1c94a1a
+  checksum: 94439e10fe1754d2b72baa41a5f5b7a633f32070ef87524b25174a6f24a201ad435679618409141a360d8011738b41be5a67c50e2b4a3863dccf064604ed706f
   languageName: node
   linkType: hard
 
 "@aws-sdk/util-locate-window@npm:^3.0.0":
-  version: 3.804.0
-  resolution: "@aws-sdk/util-locate-window@npm:3.804.0"
+  version: 3.965.5
+  resolution: "@aws-sdk/util-locate-window@npm:3.965.5"
   dependencies:
     tslib: ^2.6.2
-  checksum: 87b384533ba5ceade6e212f5783b6134551ade3ecb413c93ea453c2d5af76651137c4dc7b270b643e8ac810b072119a273790046c31921aaf0f6a664d1a31c99
+  checksum: 01a2812c7d8aac3eba50c14bb6bcf1c3c7ab37e741d1022e58143fe94e2bc74000b4b60f25ca0f1947febb3170f373e20b796beb2f799bcb60dfa9221d17b902
   languageName: node
   linkType: hard
 
@@ -1198,43 +1173,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.821.0"
+"@aws-sdk/util-user-agent-browser@npm:^3.972.8":
+  version: 3.972.8
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.972.8"
   dependencies:
-    "@aws-sdk/types": 3.821.0
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/types": ^4.13.1
     bowser: ^2.11.0
     tslib: ^2.6.2
-  checksum: 8817cc00dcc032af0a7e270dd9954b7b5f598448d8804a430456276ef560a6b4781aea4ad84377fddff3684417ac4e5925de5574d9a8b0f08832002948c4a508
+  checksum: a08c7af278b5473a59e6c6881547c4999a01bf689a757c504f356da35a2333c631847c4a2f51b2da4eb3b03cc4ff596fdaa8e4e9578f3d18d683a18e614ce096
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.835.0":
-  version: 3.835.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.835.0"
+"@aws-sdk/util-user-agent-node@npm:^3.973.11":
+  version: 3.973.11
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.973.11"
   dependencies:
-    "@aws-sdk/middleware-user-agent": 3.835.0
-    "@aws-sdk/types": 3.821.0
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/types": ^4.3.1
+    "@aws-sdk/middleware-user-agent": ^3.972.25
+    "@aws-sdk/types": ^3.973.6
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/types": ^4.13.1
+    "@smithy/util-config-provider": ^4.2.2
     tslib: ^2.6.2
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 374ba963147d741db37e26dcb999199065b2e7aa9e00c00645cbeb98b5539547113b4422a946c42196d6018fdbd14e1117d69d1c4584b4f407d60a38e800a187
+  checksum: 8c2ae770793b25e7b915a0daca3771706298091c6357f3584e799368553d060d2130eadafadb4db3a39df1145eaae3c054dd15bd9b65ca1dc37af5b369951332
   languageName: node
   linkType: hard
 
-"@aws-sdk/xml-builder@npm:3.821.0":
-  version: 3.821.0
-  resolution: "@aws-sdk/xml-builder@npm:3.821.0"
+"@aws-sdk/xml-builder@npm:^3.972.15":
+  version: 3.972.15
+  resolution: "@aws-sdk/xml-builder@npm:3.972.15"
   dependencies:
-    "@smithy/types": ^4.3.1
+    "@smithy/types": ^4.13.1
+    fast-xml-parser: 5.5.8
     tslib: ^2.6.2
-  checksum: f6ee1e5f5336afeb72e2b5e712593d1dcaa626729d0a12941c32e14136308b8729b225d4c75e7b6606bc17eeb79ea28076212aced93cc6460fefb9b712b07e28
+  checksum: 1d623536c312414f644ce9e57480f4794e332ec8d340b4bdabd175932919d0a727fd306aec3670d9dc6ca5041beb9f2b5ba7f8d4a196c8ac1190a30788ddf774
   languageName: node
   linkType: hard
 
@@ -1325,6 +1302,13 @@ __metadata:
   peerDependencies:
     aws-sdk: ^2.7.0
   checksum: 54d3aea75dd08ece0fd2c00faa610eb32ce68297de4ba21f102a568135c0693741cdb909a7ede607dca0df86cc5d571a402bdd729959c14120277670ffeb0eca
+  languageName: node
+  linkType: hard
+
+"@aws/lambda-invoke-store@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "@aws/lambda-invoke-store@npm:0.2.4"
+  checksum: 21cb364094eccf242faf824a94d8701f7bfaa50368fa232223a51b1fd49e1d46315b71c7ceec21bd186e2a72b58a47afe9080a38b0a4e8dd02257ecb5560e957
   languageName: node
   linkType: hard
 
@@ -3176,22 +3160,23 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@paradoxical-io/common-aws@workspace:packages/common-aws"
   dependencies:
-    "@aws-sdk/client-apigatewaymanagementapi": ^3.835.0
-    "@aws-sdk/client-cloudwatch-logs": ^3.835.0
-    "@aws-sdk/client-dynamodb": ^3.835.0
-    "@aws-sdk/client-kms": ^3.835.0
-    "@aws-sdk/client-s3": ^3.837.0
-    "@aws-sdk/client-sns": ^3.835.0
-    "@aws-sdk/client-sqs": ^3.835.0
-    "@aws-sdk/client-ssm": ^3.835.0
-    "@aws-sdk/client-sts": ^3.835.0
-    "@aws-sdk/cloudfront-signer": ^3.821.0
-    "@aws-sdk/credential-provider-node": ^3.835.0
-    "@aws-sdk/credential-providers": ^3.835.0
-    "@aws-sdk/s3-request-presigner": ^3.837.0
+    "@aws-sdk/client-apigatewaymanagementapi": ^3.1002.0
+    "@aws-sdk/client-cloudwatch-logs": ^3.1002.0
+    "@aws-sdk/client-dynamodb": ^3.1002.0
+    "@aws-sdk/client-kms": ^3.1002.0
+    "@aws-sdk/client-s3": ^3.1002.0
+    "@aws-sdk/client-sns": ^3.1002.0
+    "@aws-sdk/client-sqs": ^3.1002.0
+    "@aws-sdk/client-ssm": ^3.1002.0
+    "@aws-sdk/client-sts": ^3.1002.0
+    "@aws-sdk/cloudfront-signer": ^3.1002.0
+    "@aws-sdk/credential-provider-node": ^3.972.0
+    "@aws-sdk/credential-providers": ^3.1002.0
+    "@aws-sdk/s3-request-presigner": ^3.1002.0
     "@aws-sdk/util-retry": ^3.374.0
     "@aws/dynamodb-data-mapper": ^0.7.3
     "@aws/dynamodb-data-mapper-annotations": ^0.7.3
+    "@paradoxical-io/common": "workspace:packages/common"
     "@paradoxical-io/common-server": "workspace:packages/common-server"
     "@paradoxical-io/common-test": "workspace:packages/common-test"
     "@paradoxical-io/types": "workspace:packages/types"
@@ -3203,8 +3188,67 @@ __metadata:
     datadog-lambda-js: ^3.59.0
     joi: ^17.13.3
     lodash: ^4.17.21
+  peerDependencies:
+    "@aws-sdk/client-apigatewaymanagementapi": ^3.1002.0
+    "@aws-sdk/client-cloudwatch-logs": ^3.1002.0
+    "@aws-sdk/client-dynamodb": ^3.1002.0
+    "@aws-sdk/client-kms": ^3.1002.0
+    "@aws-sdk/client-s3": ^3.1002.0
+    "@aws-sdk/client-sns": ^3.1002.0
+    "@aws-sdk/client-sqs": ^3.1002.0
+    "@aws-sdk/client-ssm": ^3.1002.0
+    "@aws-sdk/client-sts": ^3.1002.0
+    "@aws-sdk/cloudfront-signer": ^3.1002.0
+    "@aws-sdk/credential-provider-node": ^3.972.0
+    "@aws-sdk/credential-providers": ^3.1002.0
+    "@aws-sdk/s3-request-presigner": ^3.1002.0
+    "@aws-sdk/util-retry": ^3.374.0
+    "@aws/dynamodb-data-mapper": ^0.7.3
+    "@aws/dynamodb-data-mapper-annotations": ^0.7.3
+    "@paradoxical-io/common-server": "workspace:packages/common-server"
+    aws-lambda: ^1.0.7
+    datadog-lambda-js: ^3.59.0
   dependenciesMeta:
     "@paradoxical-io/common-test":
+      optional: true
+  peerDependenciesMeta:
+    "@aws-sdk/client-apigatewaymanagementapi":
+      optional: true
+    "@aws-sdk/client-cloudwatch-logs":
+      optional: true
+    "@aws-sdk/client-dynamodb":
+      optional: true
+    "@aws-sdk/client-kms":
+      optional: true
+    "@aws-sdk/client-s3":
+      optional: true
+    "@aws-sdk/client-sns":
+      optional: true
+    "@aws-sdk/client-sqs":
+      optional: true
+    "@aws-sdk/client-ssm":
+      optional: true
+    "@aws-sdk/client-sts":
+      optional: true
+    "@aws-sdk/cloudfront-signer":
+      optional: true
+    "@aws-sdk/credential-provider-node":
+      optional: true
+    "@aws-sdk/credential-providers":
+      optional: true
+    "@aws-sdk/s3-request-presigner":
+      optional: true
+    "@aws-sdk/util-retry":
+      optional: true
+    "@aws/dynamodb-data-mapper":
+      optional: true
+    "@aws/dynamodb-data-mapper-annotations":
+      optional: true
+    "@paradoxical-io/common-server":
+      optional: true
+    aws-lambda:
+      optional: true
+    datadog-lambda-js:
       optional: true
   languageName: unknown
   linkType: soft
@@ -3428,188 +3472,190 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/abort-controller@npm:4.0.4"
+"@smithy/abort-controller@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/abort-controller@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 50e646633160f16d4d131c4a5612a352bca8ee652acfefc811389307756b791d0e0cee1459eeba4662e09b57e9f78681bb6c24d180d76e605126281fa52c20fb
+  checksum: bf2e381a653d316f3591adb83c7c32b22423f50a16c90f77952634d8072baaf8dcb8b6825a070ba7d9b68055bf99b205b6a935d8d2d37d71a290b2ddb86ed760
   languageName: node
   linkType: hard
 
-"@smithy/chunked-blob-reader-native@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/chunked-blob-reader-native@npm:4.0.0"
+"@smithy/chunked-blob-reader-native@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/chunked-blob-reader-native@npm:4.2.3"
   dependencies:
-    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-base64": ^4.3.2
     tslib: ^2.6.2
-  checksum: 66151ee380feac66687885f7ae0053dcc4dce85bcdf4c16fc44524c0fc038af3370fca007f0a0075610d1f49b07180bf845a3185fe36b15584be04fa9a635e98
+  checksum: ecc8387a6c8ded5d25c5cfaa7a163f716d2d81447bcc8c5f51990859ab848347295c699fd9dce4be6659505f0045e0b43723e6a9632fd975c647ab1799016b34
   languageName: node
   linkType: hard
 
-"@smithy/chunked-blob-reader@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@smithy/chunked-blob-reader@npm:5.0.0"
+"@smithy/chunked-blob-reader@npm:^5.2.2":
+  version: 5.2.2
+  resolution: "@smithy/chunked-blob-reader@npm:5.2.2"
   dependencies:
     tslib: ^2.6.2
-  checksum: ee4c1a33a422f684391d5d4cb290f46e2f8e024f31dbba5e31e3def71fd1fa79a357c83ee2ccaea555face2024b0f43ed27569608489bfa9ecfdd4681705b7ae
+  checksum: 36e5f3e7872d9821aa1b3e88dbbe564684cfe978c7e9cdb99990404b54fa1f35c38ee0d8b8734abbf63ab6af560e13980ce97a80594fc95fb8b1e7b62519e0f1
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^4.1.4":
-  version: 4.1.4
-  resolution: "@smithy/config-resolver@npm:4.1.4"
+"@smithy/config-resolver@npm:^4.4.13":
+  version: 4.4.13
+  resolution: "@smithy/config-resolver@npm:4.4.13"
   dependencies:
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/types": ^4.3.1
-    "@smithy/util-config-provider": ^4.0.0
-    "@smithy/util-middleware": ^4.0.4
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/types": ^4.13.1
+    "@smithy/util-config-provider": ^4.2.2
+    "@smithy/util-endpoints": ^3.3.3
+    "@smithy/util-middleware": ^4.2.12
     tslib: ^2.6.2
-  checksum: d3c3b7017377ae30839d3bc684fca7ff58c41c2ca71dd067931aff61f0c570b09cf35e47fde660488c7e1ecc8e1abf720bd41f380b9a91ea302fbd7c7f1b85fb
+  checksum: 26fdc6e98a408716675c37a1fd4676d3108991e5fdf4264ed1774bce1f0ec28c9cba21506d4efa220e8cae8da61ba1cfff9fa8046187cec96f5d00ef792746ba
   languageName: node
   linkType: hard
 
-"@smithy/core@npm:^3.5.3, @smithy/core@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "@smithy/core@npm:3.6.0"
+"@smithy/core@npm:^3.23.12":
+  version: 3.23.12
+  resolution: "@smithy/core@npm:3.23.12"
   dependencies:
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-body-length-browser": ^4.0.0
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-stream": ^4.2.2
-    "@smithy/util-utf8": ^4.0.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-body-length-browser": ^4.2.2
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-stream": ^4.5.20
+    "@smithy/util-utf8": ^4.2.2
+    "@smithy/uuid": ^1.1.2
     tslib: ^2.6.2
-  checksum: fe381bff50194c0ff0e63541623e0ee1c84d78084919b6c56d7fb5d4bc08d3aa42c63a348767ce2a685370096fe3c2b4d0e2a922fef3650cc36699a80bdbcac5
+  checksum: 02a5cdac710f457e75ba300f3b368893a007e2987eaa979d84e09bffa2be63df960bf235aec86b8ddd9655d1e81669d2fc0e010b15f0cb088deed302de70b122
   languageName: node
   linkType: hard
 
-"@smithy/credential-provider-imds@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "@smithy/credential-provider-imds@npm:4.0.6"
+"@smithy/credential-provider-imds@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/credential-provider-imds@npm:4.2.12"
   dependencies:
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
     tslib: ^2.6.2
-  checksum: 380ada77c7cc7f6e11ee4246a335799cd855b43df07469164ca7ccaeecd1eb8e037adf0b870e57578de7f82bb1f77e5d534c55ed3aa44491fcef55809b5d1d5c
+  checksum: d9038bd1458cb2e8d984e97229ead6f3cffaacaf2a6f93b2e63174b50dda9688d5202b6c10411f9f774a0322839c22723c4fe346bb131a6394a32b8dd530c634
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-codec@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/eventstream-codec@npm:4.0.4"
+"@smithy/eventstream-codec@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/eventstream-codec@npm:4.2.12"
   dependencies:
     "@aws-crypto/crc32": 5.2.0
-    "@smithy/types": ^4.3.1
-    "@smithy/util-hex-encoding": ^4.0.0
+    "@smithy/types": ^4.13.1
+    "@smithy/util-hex-encoding": ^4.2.2
     tslib: ^2.6.2
-  checksum: b5ff1a2c9f8ea48406f181c0104daf56e1f52bf251cfc531f497abce86f02a148d381ee1648bcd34a4c2293b8e0e052c02043755ffeb864421957fa320c74435
+  checksum: 7823ba2570875a00b9ef0841f438dfaf289a9cffd98ed12da514515f9c2aa0d3bff77c643c094f7f742aa3b6736cd8d6687d1e60540b8582e9b875e8c9742e6e
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-browser@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/eventstream-serde-browser@npm:4.0.4"
+"@smithy/eventstream-serde-browser@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/eventstream-serde-browser@npm:4.2.12"
   dependencies:
-    "@smithy/eventstream-serde-universal": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@smithy/eventstream-serde-universal": ^4.2.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 1d39b5da8fe1fd060d47f41f25b70ea4291c8ae2e4f5ea79bf1849a72af88ab0d819618e5b02606b1758084ce43964a92ffc36688817409dcabacd36a8a2266a
+  checksum: e94b5a4ba54b036d2137b8409e8d1fae333b9b528f629b4e7c1633f97adb775fe6ee92ba252b578775c45bab805c8d3397310d0327f9fb033d4f60619dab50fb
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-config-resolver@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.1.2"
+"@smithy/eventstream-serde-config-resolver@npm:^4.3.12":
+  version: 4.3.12
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.3.12"
   dependencies:
-    "@smithy/types": ^4.3.1
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 42b81e6c92029966f373be7eb589e1292a201e191965b62f1ff71a4e6b5dabf874850a8b65441fa9cec735aad018365a3e841f95af7443288130603be00a7996
+  checksum: 73285d29dabfc35b981aa25315106076d3b1a67512a663785c659d9c81cb875e46263898b9c16c9cd901a47c01e5e2d4481dda24942d04db689dcf96dd6d6a00
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-node@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/eventstream-serde-node@npm:4.0.4"
+"@smithy/eventstream-serde-node@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/eventstream-serde-node@npm:4.2.12"
   dependencies:
-    "@smithy/eventstream-serde-universal": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@smithy/eventstream-serde-universal": ^4.2.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 179dd707b0f730c36ab68b1cfdbd0c6f29012a25bf3fec564076217a929627e119ccae8e5df34c267c1df8512c6294c10aa74e0511ab82b767f4a7ef39209519
+  checksum: 17482075912cef131076eab8642119ad6ddb09d526e87a2ef4b10bf676fbc0957645d42d0bf72073d75ae2f540f5b647b27c42800018ee602f247f0ee53c49a0
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-universal@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/eventstream-serde-universal@npm:4.0.4"
+"@smithy/eventstream-serde-universal@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/eventstream-serde-universal@npm:4.2.12"
   dependencies:
-    "@smithy/eventstream-codec": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@smithy/eventstream-codec": ^4.2.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 53cf083f742f2fa381a0d0457e3fbfe3b36b65efec216f52d21f840382466b59c64e685a65412925b60a3def11e24e4bd6bcd3bb5afad336f3fafab2bb2cbd48
+  checksum: b7bc845a3ffd2bb915f90dd9a57b47d45021856ecfa981c12f85a58aa8c8881b5d1f2911bc1f4c4d6732a2612f3fba429e952ae9485acca8bb1f2afe0fe29393
   languageName: node
   linkType: hard
 
-"@smithy/fetch-http-handler@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "@smithy/fetch-http-handler@npm:5.0.4"
+"@smithy/fetch-http-handler@npm:^5.3.15":
+  version: 5.3.15
+  resolution: "@smithy/fetch-http-handler@npm:5.3.15"
   dependencies:
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/querystring-builder": ^4.0.4
-    "@smithy/types": ^4.3.1
-    "@smithy/util-base64": ^4.0.0
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/querystring-builder": ^4.2.12
+    "@smithy/types": ^4.13.1
+    "@smithy/util-base64": ^4.3.2
     tslib: ^2.6.2
-  checksum: 3afb020d42e50d6bb446ceb8efe0cb33a05b449a15156459eea5717860e785f56a9166eb08455b7c1fd3af277bbca4b708e4d8cccda37519f44aa4990e3f50d4
+  checksum: fdaa8b0261e948f7beafc7e29ced09a49cb2bc0ec001a4756d54aa6e55a3255ad19756e3b0d80fa5207f652f6646569a787d89eeee96fbf326865418b46a7d84
   languageName: node
   linkType: hard
 
-"@smithy/hash-blob-browser@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/hash-blob-browser@npm:4.0.4"
+"@smithy/hash-blob-browser@npm:^4.2.13":
+  version: 4.2.13
+  resolution: "@smithy/hash-blob-browser@npm:4.2.13"
   dependencies:
-    "@smithy/chunked-blob-reader": ^5.0.0
-    "@smithy/chunked-blob-reader-native": ^4.0.0
-    "@smithy/types": ^4.3.1
+    "@smithy/chunked-blob-reader": ^5.2.2
+    "@smithy/chunked-blob-reader-native": ^4.2.3
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 39636cba0fb306835b8079e6bfeb534b9d9a2aa926beee90fb59a442d256ccf4600b1ca331ed92ed9778656885450cc4b4a9d71b22a349014acf379024188621
+  checksum: 5cdff88db13f149b2e00e1887635ea55ef0eaf4804987b81af12f61b6f7af9e9139e5e687b49d5017d90a42f1852e02cb72890e31e18c0bcf8bf6ee62bf4d3b7
   languageName: node
   linkType: hard
 
-"@smithy/hash-node@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/hash-node@npm:4.0.4"
+"@smithy/hash-node@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/hash-node@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
-    "@smithy/util-buffer-from": ^4.0.0
-    "@smithy/util-utf8": ^4.0.0
+    "@smithy/types": ^4.13.1
+    "@smithy/util-buffer-from": ^4.2.2
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: 2fd8a1036b9d6d2948249ad41a97b5801b918948ab1f8041b2b2482848570e8b417eeea7810f959376325e9ab33890775025b34a58305355b84ca8bff1417481
+  checksum: be7ba82b6c8fad217764da762085d3d6c48df183fe6c7f06bbca38a7766d51c3e6a3f2d899e6fb7bfa2f86f6ec30b05e4beccaef6282ef9a3cc692a5f216451a
   languageName: node
   linkType: hard
 
-"@smithy/hash-stream-node@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/hash-stream-node@npm:4.0.4"
+"@smithy/hash-stream-node@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/hash-stream-node@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
-    "@smithy/util-utf8": ^4.0.0
+    "@smithy/types": ^4.13.1
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: 0753a498f2d06e2abd9e15668a0ddda71520cc75bb587c10ad85a94e5cb61f68c7c2d85ab0252bf949fd5abdebea9dabc3acfae3ef2d8e2aeb630079d5b831c3
+  checksum: 3956f34d32cd3a7f8242d77c164911a694bc1c42a2453a938e5d517ed80ae86c244118cce6d898743293b49862d77019c718215a76462c2471a98e88919837ab
   languageName: node
   linkType: hard
 
-"@smithy/invalid-dependency@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/invalid-dependency@npm:4.0.4"
+"@smithy/invalid-dependency@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/invalid-dependency@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 6d6f53558cb252e2070e4830a18c0c72ad486308378d6eab2a185d63f5a0492ffbdff27dbea59f79e2d48477af2295e80d6314becf9ea3215827be8bb6690b07
+  checksum: e558d6b3edab1a648b616f9c6821cace5e568811163dfdd33a003c7e87ae61f0cbcec121800a42968ac2a153ea0e6dd03e53f702bddaab761f97b98e35ce0b2b
   languageName: node
   linkType: hard
 
@@ -3622,154 +3668,155 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/is-array-buffer@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/is-array-buffer@npm:4.0.0"
+"@smithy/is-array-buffer@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/is-array-buffer@npm:4.2.2"
   dependencies:
     tslib: ^2.6.2
-  checksum: 8226fc1eca7aacd7f887f3a5ec2f15a3cafa72aa1c42d3fc759c66600481381d18ec7285a8195f24b9c4fe0ce9a565c133b2021d86a8077aebce3f86b3716802
+  checksum: 7699ddab02a9c2443bd64064e6cd81bb352112c90198820d08e1c79ccd536080a111f5c681b63be2bcc025660f3b66eb24d6e6f00aa0b8f34de557b486928b52
   languageName: node
   linkType: hard
 
-"@smithy/md5-js@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/md5-js@npm:4.0.4"
+"@smithy/md5-js@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/md5-js@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
-    "@smithy/util-utf8": ^4.0.0
+    "@smithy/types": ^4.13.1
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: f4a0d7adbd6fecce963c28cfb3959a370579969d845034cc2bc8e24f305b124d1993ab1f6cb2a3577255ed43e61de6957a774d1caf277d668f56c8a231745112
+  checksum: 72634fc7098110a6ae0b04f3e4d3c1571cf224d578dd96e8796d7927865ce00adc42c1bbcc31c97db2610b450da35013130d3d821a47bc75fe1228fe6ae880bb
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/middleware-content-length@npm:4.0.4"
+"@smithy/middleware-content-length@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/middleware-content-length@npm:4.2.12"
   dependencies:
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 251e47fbb7df19a8c39719f96dfd9e00252fc33733d2585898b7e5a37e85056052de1559d3c62b9daf493e2293b574ac2e92e17806777cadc9b733f1aab42294
+  checksum: ca9b5db05fb5939ba61b9e9bf3d6d17e57420bb685917ce3ffba230716a772409a4195417dde697dfd9672f22c485daad321c30f25b4b8ddd9e306cf983b509a
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^4.1.12, @smithy/middleware-endpoint@npm:^4.1.13":
-  version: 4.1.13
-  resolution: "@smithy/middleware-endpoint@npm:4.1.13"
+"@smithy/middleware-endpoint@npm:^4.4.27":
+  version: 4.4.27
+  resolution: "@smithy/middleware-endpoint@npm:4.4.27"
   dependencies:
-    "@smithy/core": ^3.6.0
-    "@smithy/middleware-serde": ^4.0.8
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/shared-ini-file-loader": ^4.0.4
-    "@smithy/types": ^4.3.1
-    "@smithy/url-parser": ^4.0.4
-    "@smithy/util-middleware": ^4.0.4
+    "@smithy/core": ^3.23.12
+    "@smithy/middleware-serde": ^4.2.15
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/shared-ini-file-loader": ^4.4.7
+    "@smithy/types": ^4.13.1
+    "@smithy/url-parser": ^4.2.12
+    "@smithy/util-middleware": ^4.2.12
     tslib: ^2.6.2
-  checksum: 38a8ab4835a225a22a176699e9941ce912212af9db9e14dfcd76e4daad14bc7fc4896631b2cd44f4104ff199acd2bfd5f08e6ee757a6aff69a1376e93e89790d
+  checksum: ac3378e14cb53ec1ee0ee4e46fa8755889e87b5eb3b25feb52c78df1da6c752c7a90f4fe3d98adfe96c3ba6007adfb7e71fd19eca03063488217a796d7000bcd
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^4.1.13":
-  version: 4.1.14
-  resolution: "@smithy/middleware-retry@npm:4.1.14"
+"@smithy/middleware-retry@npm:^4.4.44":
+  version: 4.4.44
+  resolution: "@smithy/middleware-retry@npm:4.4.44"
   dependencies:
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/service-error-classification": ^4.0.6
-    "@smithy/smithy-client": ^4.4.5
-    "@smithy/types": ^4.3.1
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-retry": ^4.0.6
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/service-error-classification": ^4.2.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-retry": ^4.2.12
+    "@smithy/uuid": ^1.1.2
     tslib: ^2.6.2
-    uuid: ^9.0.1
-  checksum: 801fa598c7177719e3c2be6a5cf45e5184ca3a95e56cccee43a20c95cfc17397d02ac7da357045cc8b0643e385d625f3b90c37c5a68dbbce4da4bbc0732e69f3
+  checksum: 9e3f97a1f9ff5d2e74930ac3d7ee5a39e1005e54a13052dd8eea65a85ffd05ebd182a3a6af321a05e63263f3e4c134d6c3ecb361717d565c22f7ad6c18ad2e87
   languageName: node
   linkType: hard
 
-"@smithy/middleware-serde@npm:^4.0.8":
-  version: 4.0.8
-  resolution: "@smithy/middleware-serde@npm:4.0.8"
+"@smithy/middleware-serde@npm:^4.2.15":
+  version: 4.2.15
+  resolution: "@smithy/middleware-serde@npm:4.2.15"
   dependencies:
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
+    "@smithy/core": ^3.23.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 1c78cf584bf82c2ed80d55694945d63b5d3bdaf0c4dea1a35ff33b201d939e9ee5afbfb01c6725c9cbc0d9efb3ee50703970d177a9d20dba545e7e7ba3c0a3f5
+  checksum: 998f26554b1a33cb6d2a6dcc0e6711504d2157053c3f2b01f490adbbc93c252912a94aee251cf910608e4261661ef770a0cd8f7f7dabfaefcdaf8d425b9caa85
   languageName: node
   linkType: hard
 
-"@smithy/middleware-stack@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/middleware-stack@npm:4.0.4"
+"@smithy/middleware-stack@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/middleware-stack@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: c0b4e057d438fbc900435a4bcae68308bc17361968ebe828d43b4f78d826711e5d196ea2fc3ef86525169508d885979e459db0d46918ae00a2bb5dc8a5bd6796
+  checksum: a056c6c4ba806665488e0b4e79b6d0dcd6dae3236c5c0dc2e3d3529bd82599543b2c6f155ce71c9921ae8c5ba4fde531c234d979be4ada1a87a960d4d88bac78
   languageName: node
   linkType: hard
 
-"@smithy/node-config-provider@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "@smithy/node-config-provider@npm:4.1.3"
+"@smithy/node-config-provider@npm:^4.3.12":
+  version: 4.3.12
+  resolution: "@smithy/node-config-provider@npm:4.3.12"
   dependencies:
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/shared-ini-file-loader": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/shared-ini-file-loader": ^4.4.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: c1260719f567b64e979e54698356ffd49f26d82e5eaafc60741588257df6016bbf7d2e26cba902ff900058e5e47e985287fdcb7ab1acdf6534b7cd50252e3856
+  checksum: 0f458c110c6ed56664515196e9156d2263891a1610a41325972d357d29c7977c3810491df0077f410ca50242bd9277a2577f343b5062d1c631d49c184d600b41
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "@smithy/node-http-handler@npm:4.0.6"
+"@smithy/node-http-handler@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "@smithy/node-http-handler@npm:4.5.0"
   dependencies:
-    "@smithy/abort-controller": ^4.0.4
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/querystring-builder": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@smithy/abort-controller": ^4.2.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/querystring-builder": ^4.2.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: b0505a812182f29e4ff254f4710a476e0dd9a869248b5c9972ddaaf0c1bef9dc980682947826d5a24c3b54c635ad6a1d7ac6460e61ac99da8becc4ecda55e768
+  checksum: b26831eab854dbcdb1d608e0085d8379a42a7d4249c772323dda35da76e20e39981867e4e55154dd4228d52b6815cf8afb9488ec4aac1dd99794d540afc70426
   languageName: node
   linkType: hard
 
-"@smithy/property-provider@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/property-provider@npm:4.0.4"
+"@smithy/property-provider@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/property-provider@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 1cd552792897e43c1d4cf91edac0956a8a8d6a7ba588e46532644ae5aca535ec0fb33e3aa71c73f325632b72cd1b8f26732525a6723f74c54238026432b0118e
+  checksum: e3172eeba2a7e96610ebca0708b4e3f2f27f492d61c9769897527a421192053f56ef8bf9d3498301267e0b126cb291e326dd95d30dd5c0c3472cbc448e879717
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "@smithy/protocol-http@npm:5.1.2"
+"@smithy/protocol-http@npm:^5.3.12":
+  version: 5.3.12
+  resolution: "@smithy/protocol-http@npm:5.3.12"
   dependencies:
-    "@smithy/types": ^4.3.1
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 48dbb715956f7089f3422c6c875fd5c6c901bb55363091905f749bba4bac03c40bf11e63dcc92c9b5de058305c60513e987e1fd7550e585c9e2a98e7355676c8
+  checksum: f40fd09a7c810f93ed767df5f4504bd330a5ab233fa4ddfbcab6c13e5a3d4948f23ddf443be385c4dcef538f45deb92b4c749a5922b597e389e98fd2bf533f39
   languageName: node
   linkType: hard
 
-"@smithy/querystring-builder@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/querystring-builder@npm:4.0.4"
+"@smithy/querystring-builder@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/querystring-builder@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
-    "@smithy/util-uri-escape": ^4.0.0
+    "@smithy/types": ^4.13.1
+    "@smithy/util-uri-escape": ^4.2.2
     tslib: ^2.6.2
-  checksum: e521cd60294aebabb11386f4db7925095ca7dcdd1eda1904ad3443aa65c992a74e7d57b24018c3e141320bcc8b8928a24b8a14c4328bc7176bdb1eac15f6655b
+  checksum: ce222888666797162554df507271fa526e6e56964e0af9cbfa955f6defeeaf9c029368318d82d703e2f30b1977334448e6fd6a6f99f720999a4ea54ee284fbd6
   languageName: node
   linkType: hard
 
-"@smithy/querystring-parser@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/querystring-parser@npm:4.0.4"
+"@smithy/querystring-parser@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/querystring-parser@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: ebe874dfec44ec3d6ff63f9570cac7c18f5b1b2fb3d6a72722adb9d24bb891970fbbabb18d15b8ce46902cc5f21f1751218794f3ff2e110865804d822f4b83a0
+  checksum: 2d199d4d427f361f9bbf296f35d066e265f19edbd58dbbd656001a0913140645c3e559f951e4dacfe38774b27185c946c59263ac1020e9246552010f68a1875d
   languageName: node
   linkType: hard
 
@@ -3780,102 +3827,120 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/service-error-classification@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "@smithy/service-error-classification@npm:4.0.6"
+"@smithy/service-error-classification@npm:^2.0.4":
+  version: 2.1.5
+  resolution: "@smithy/service-error-classification@npm:2.1.5"
   dependencies:
-    "@smithy/types": ^4.3.1
-  checksum: c851c882358af75cac41508ffdd2cfdc59e0cd298cb25cf6a4a97dd6cbc92f4890ce04590305726ebb1bbb6b6c527dde8d80ec84095c76bcdb6a3a1cc2107a90
+    "@smithy/types": ^2.12.0
+  checksum: 00ac54110a258c7a47c62d4f655d4998bd40e5adb47e10281b28df7a585f2f1e960dc35325eac006636280e7fb2b81dbeb32b89e08bac87acc136c4d29a4dc53
   languageName: node
   linkType: hard
 
-"@smithy/shared-ini-file-loader@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/shared-ini-file-loader@npm:4.0.4"
+"@smithy/service-error-classification@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/service-error-classification@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
-    tslib: ^2.6.2
-  checksum: b9405d3fea03cb7d1b031a41d7a91581eaaf47a5e6322c7bf2c57e27bcf8af403eea68c46a9c878a31af8a1f08fa803fce3d253c55b3318548fc93d61b0e56e8
+    "@smithy/types": ^4.13.1
+  checksum: 8c9a727dcfe15b04aeecebd372552a328814a013557997fdf9721776b1ce3b8595a17e234ef0bed4b8bf2d815f013df3d34ceb02973228c7b4e8edc4867cf1e3
   languageName: node
   linkType: hard
 
-"@smithy/signature-v4@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "@smithy/signature-v4@npm:5.1.2"
+"@smithy/shared-ini-file-loader@npm:^4.4.7":
+  version: 4.4.7
+  resolution: "@smithy/shared-ini-file-loader@npm:4.4.7"
   dependencies:
-    "@smithy/is-array-buffer": ^4.0.0
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
-    "@smithy/util-hex-encoding": ^4.0.0
-    "@smithy/util-middleware": ^4.0.4
-    "@smithy/util-uri-escape": ^4.0.0
-    "@smithy/util-utf8": ^4.0.0
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: b8acbdd600279be860650b8c99ea443b653f0a980a9aceb7cdf8bf0f017d0376a4aac9bef738c24aa0c2f12b3ae1984bf1ed5d99235f64a9ff41a7fcd851b531
+  checksum: e510806dc77bf9bc2d0b51ebd8a613e77520b24c78ecaa11e4482e09e74001d748c4385bfb38420bcaa2a9a081d76ff6a500c209eaa546016baa35e634cca189
   languageName: node
   linkType: hard
 
-"@smithy/smithy-client@npm:^4.4.4, @smithy/smithy-client@npm:^4.4.5":
-  version: 4.4.5
-  resolution: "@smithy/smithy-client@npm:4.4.5"
+"@smithy/signature-v4@npm:^5.3.12":
+  version: 5.3.12
+  resolution: "@smithy/signature-v4@npm:5.3.12"
   dependencies:
-    "@smithy/core": ^3.6.0
-    "@smithy/middleware-endpoint": ^4.1.13
-    "@smithy/middleware-stack": ^4.0.4
-    "@smithy/protocol-http": ^5.1.2
-    "@smithy/types": ^4.3.1
-    "@smithy/util-stream": ^4.2.2
+    "@smithy/is-array-buffer": ^4.2.2
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
+    "@smithy/util-hex-encoding": ^4.2.2
+    "@smithy/util-middleware": ^4.2.12
+    "@smithy/util-uri-escape": ^4.2.2
+    "@smithy/util-utf8": ^4.2.2
     tslib: ^2.6.2
-  checksum: c5764145091cf22ae2a3fb7b10c9b8907ca8a46265920ff8b8a2a55a04f489a417b1f42721bc80fd5d4ac88b3330a9d47090bca2b11e42f52299b19feea4e1b5
+  checksum: 52987459b351a17f24638c0a8370b034711ada717ed919ec9d9349f59ca9903c97cbbeb396959ebb59c823de436c6b062d44f133043c47701c2e34d32a9f21e6
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^4.3.1":
-  version: 4.3.1
-  resolution: "@smithy/types@npm:4.3.1"
+"@smithy/smithy-client@npm:^4.12.7":
+  version: 4.12.7
+  resolution: "@smithy/smithy-client@npm:4.12.7"
   dependencies:
+    "@smithy/core": ^3.23.12
+    "@smithy/middleware-endpoint": ^4.4.27
+    "@smithy/middleware-stack": ^4.2.12
+    "@smithy/protocol-http": ^5.3.12
+    "@smithy/types": ^4.13.1
+    "@smithy/util-stream": ^4.5.20
     tslib: ^2.6.2
-  checksum: 45f2e15cec06eefb6a2470346c65ec927e56ab1757eee5ab1c431f703a9b350b331679e1f60105a1529ecb9cdb953104883942e655701fb4710bbaf566ec0bc6
+  checksum: 8fcc13be79f8bc93b036ba112bf9c817b9d91be57d2ba506c866e1b0894a53f15558f8065c15873cb406b1f3f34d05dcf69f6f51e750e2d0724e0954d34d61d6
   languageName: node
   linkType: hard
 
-"@smithy/url-parser@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/url-parser@npm:4.0.4"
+"@smithy/types@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "@smithy/types@npm:2.12.0"
   dependencies:
-    "@smithy/querystring-parser": ^4.0.4
-    "@smithy/types": ^4.3.1
     tslib: ^2.6.2
-  checksum: 1d3df1c58809f424af00396f987607ec9ebb0840625e4353af6dcd6baf480db8dd080b2f01ed41598ff18681ab2fcecab37f18f4c253fcbdd71eab2fab049400
+  checksum: 2dd93746624d87afbf51c22116fc69f82e95004b78cf681c4a283d908155c22a2b7a3afbd64a3aff7deefb6619276f186e212422ad200df3b42c32ef5330374e
   languageName: node
   linkType: hard
 
-"@smithy/util-base64@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-base64@npm:4.0.0"
+"@smithy/types@npm:^4.13.1":
+  version: 4.13.1
+  resolution: "@smithy/types@npm:4.13.1"
   dependencies:
-    "@smithy/util-buffer-from": ^4.0.0
-    "@smithy/util-utf8": ^4.0.0
     tslib: ^2.6.2
-  checksum: 7fb3430d6e1cbb4bcc61458587bb0746458f0ec8e8cd008224ca984ff65c3c3307b3a528d040cef4c1fc7d1bd4111f6de8f4f1595845422f14ac7d100b3871b1
+  checksum: 615dd29f7b5a9d2f3910842d9883660142eec12ec5caaf3f59903c5a41cc81521d3748de5a3bd7593881f61938c0d812e54043a51955adcc076384fa3ef5b5d8
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-browser@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-body-length-browser@npm:4.0.0"
+"@smithy/url-parser@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/url-parser@npm:4.2.12"
   dependencies:
+    "@smithy/querystring-parser": ^4.2.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 72381e12de7cccbb722c60e3f3ae0f8bce7fc9a9e8064c7968ac733698a5a30bea098a3c365095c519491fe64e2e949c22f74d4f1e0d910090d6389b41c416eb
+  checksum: b28df0caa6a15a0686ea841508d1aead75c5f49d79664324c4b6b063b0ec39bd9880c71af2fb7ea1d2caf9afe212c4e20aa02dc5cceaea10d2b2a9ded69692cb
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-node@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-body-length-node@npm:4.0.0"
+"@smithy/util-base64@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@smithy/util-base64@npm:4.3.2"
+  dependencies:
+    "@smithy/util-buffer-from": ^4.2.2
+    "@smithy/util-utf8": ^4.2.2
+    tslib: ^2.6.2
+  checksum: 91ad0412c5c0b34cae701e8cb24a2dcdb9ad011207b3c785124a08d2228f2b01d12479f2ae42ede34364442a4e82459370175c77a99634c1c4799acf756a1013
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-browser@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-body-length-browser@npm:4.2.2"
   dependencies:
     tslib: ^2.6.2
-  checksum: 12d8de9c526647f51f56804044f5847f0c7c7afee30fa368d2b7bd4b4de8fe2438a925aab51965fe8a4b2f08f68e8630cc3c54a449beae6646d99cae900ed106
+  checksum: 6c8a80ee861092a494d436530dfeba6da0012071116e5fb21b0380945204101c154a74b40c2409cbb7c567b992b3203010e9e21274dfa53d244ae42aba95ae80
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-node@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "@smithy/util-body-length-node@npm:4.2.3"
+  dependencies:
+    tslib: ^2.6.2
+  checksum: 4720c493fd5aa381e4315457b75935ffd3573c619f3c21e340282f9ca4d53a6214ed07eb2407f0eaac8437ea331f85d5696c203b5961df7491d58fdc8fd7c7a0
   languageName: node
   linkType: hard
 
@@ -3889,80 +3954,79 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-buffer-from@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-buffer-from@npm:4.0.0"
+"@smithy/util-buffer-from@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-buffer-from@npm:4.2.2"
   dependencies:
-    "@smithy/is-array-buffer": ^4.0.0
+    "@smithy/is-array-buffer": ^4.2.2
     tslib: ^2.6.2
-  checksum: 8124e28d3e34b5335c08398a9081cc56a232d23e08172d488669f91a167d0871d36aba9dd3e4b70175a52f1bd70e2bf708d4c989a19512a4374d2cf67650a15e
+  checksum: 4972e7e7a8fb4d7b63164bbeaa9fd211fb13a2649eeb789b0ef7f7565018ac3262ed055fec191a9950080a126986d0160c73523668a38d7a41a5b1359781eacc
   languageName: node
   linkType: hard
 
-"@smithy/util-config-provider@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-config-provider@npm:4.0.0"
+"@smithy/util-config-provider@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-config-provider@npm:4.2.2"
   dependencies:
     tslib: ^2.6.2
-  checksum: 91bd9e0bec4c4a37c3fc286e72f3387be9272b090111edaee992d9e9619370f3f2ad88ce771ef42dbfe40a44500163b633914486e662526591f5f737d5e4ff5a
+  checksum: 8bb1a040ee2ba4ecbcf6965906c3f8d92a1819cb5a444e0b7be7a011517cb452d20368d766699f6a2e250eba5ee5cf87d031f614fdb4c32a04097974512be5d1
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^4.0.20":
-  version: 4.0.21
-  resolution: "@smithy/util-defaults-mode-browser@npm:4.0.21"
+"@smithy/util-defaults-mode-browser@npm:^4.3.43":
+  version: 4.3.43
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.43"
   dependencies:
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/smithy-client": ^4.4.5
-    "@smithy/types": ^4.3.1
-    bowser: ^2.11.0
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: e9f26b600897b85b39e1e7fecd432413885d240bbdd7a9b080d47e0bac5fee7f88e3631c3b11f407f22ab81f6a67691a3d981318b1ab86578fc3f49afd8ad6d6
+  checksum: bdb9235da51432eea17d63d66eb3428541b67ec30e192c6b90cf0a7915efecbffe254d067a3b4a97ebe1c73b452bd268d7e5a73f51ba678fd70630ffea91fb4b
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^4.0.20":
-  version: 4.0.21
-  resolution: "@smithy/util-defaults-mode-node@npm:4.0.21"
+"@smithy/util-defaults-mode-node@npm:^4.2.47":
+  version: 4.2.47
+  resolution: "@smithy/util-defaults-mode-node@npm:4.2.47"
   dependencies:
-    "@smithy/config-resolver": ^4.1.4
-    "@smithy/credential-provider-imds": ^4.0.6
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/property-provider": ^4.0.4
-    "@smithy/smithy-client": ^4.4.5
-    "@smithy/types": ^4.3.1
+    "@smithy/config-resolver": ^4.4.13
+    "@smithy/credential-provider-imds": ^4.2.12
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/property-provider": ^4.2.12
+    "@smithy/smithy-client": ^4.12.7
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 2c8e6e112c2284f2f9a54ca615ab2bac4df58321d220b3240318b0db8cc158d3994f87d97069c4d1748302153f26f5a1a7a388c55182ffd04e3556be20161c0c
+  checksum: a46f8858192124e4b9cad5d5f130448ee8795ad0fe1f83284e289d1dbc386982c095e0f63c0403277d82a4a7b38830555f16d4b36927c56db0dc8b7a13dae3c0
   languageName: node
   linkType: hard
 
-"@smithy/util-endpoints@npm:^3.0.6":
-  version: 3.0.6
-  resolution: "@smithy/util-endpoints@npm:3.0.6"
+"@smithy/util-endpoints@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "@smithy/util-endpoints@npm:3.3.3"
   dependencies:
-    "@smithy/node-config-provider": ^4.1.3
-    "@smithy/types": ^4.3.1
+    "@smithy/node-config-provider": ^4.3.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 185c096db895f5bfabc05f1500d3428761fc4d450e998d6bf269879f7fc3f6fd770c1ed5a2de395a6b5300197bd40748a5b06c74b91ff01c9c499a25f2ba827e
+  checksum: dae8713315c10abed93fb08308b969471dee6f16a836cd85d6a04457d1d678782425e1948b7abb98a5ad2e399cb11aa1a1f18ff9449e1dd01aebc46f2c524cb9
   languageName: node
   linkType: hard
 
-"@smithy/util-hex-encoding@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-hex-encoding@npm:4.0.0"
+"@smithy/util-hex-encoding@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-hex-encoding@npm:4.2.2"
   dependencies:
     tslib: ^2.6.2
-  checksum: b932fa0e5cd2ba2598ad55ce46722bbbd15109809badaa3e4402fe4dd6f31f62b9fb49d2616e38d660363dc92a5898391f9c8f3b18507c36109e908400785e2a
+  checksum: 85e1195258a2be4855890b517c6fd13104d1c9e2cd70626c15f547000e801a08afe062bf94bcd995b7dfbc4ad61f8b550d3f6c25c0e85eb1a7708a9f9909b7e3
   languageName: node
   linkType: hard
 
-"@smithy/util-middleware@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@smithy/util-middleware@npm:4.0.4"
+"@smithy/util-middleware@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/util-middleware@npm:4.2.12"
   dependencies:
-    "@smithy/types": ^4.3.1
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 6cfdec16f03cc963e78d888a0ef349c0d80645775e9933a88c4615fbd5a683a8230997f89372e2597bd956bc05df5adc41de6524fa8c0cc93fb7150d6530a03b
+  checksum: 9ec332ef118d5ddc185ad31ccd976d233861d1023e6a66357ccacf52c96501dcf7424cfb52a94f2426f1c554cf7c083f9ab2e315922bfb405d52861580642066
   languageName: node
   linkType: hard
 
@@ -3976,39 +4040,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "@smithy/util-retry@npm:4.0.6"
+"@smithy/util-retry@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "@smithy/util-retry@npm:4.2.12"
   dependencies:
-    "@smithy/service-error-classification": ^4.0.6
-    "@smithy/types": ^4.3.1
+    "@smithy/service-error-classification": ^4.2.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 0faef3d90da51024a5abd90de6bf1a846b6cd0f61c78791a2fecc7e49b0e8a705ca5619ae538cad4bab8995456d8219fe1c2769dacd156195cb73befcb02ca03
+  checksum: f78e36ea0457fbe338c6080bc1dab1c57893921361e7d2206eff8c0415c667dd89c8c1c9e4bedf749d08b5953c58c98b26cb2a836da5eba063c2b853c6131edb
   languageName: node
   linkType: hard
 
-"@smithy/util-stream@npm:^4.2.2":
+"@smithy/util-stream@npm:^4.5.20":
+  version: 4.5.20
+  resolution: "@smithy/util-stream@npm:4.5.20"
+  dependencies:
+    "@smithy/fetch-http-handler": ^5.3.15
+    "@smithy/node-http-handler": ^4.5.0
+    "@smithy/types": ^4.13.1
+    "@smithy/util-base64": ^4.3.2
+    "@smithy/util-buffer-from": ^4.2.2
+    "@smithy/util-hex-encoding": ^4.2.2
+    "@smithy/util-utf8": ^4.2.2
+    tslib: ^2.6.2
+  checksum: fb87e3f61c9dca31e484751fff90147912ccbb0b3a4d26997555a199ff4cbfee461b960879317562e088ee7a6aeea0b328c38632bc439bb3a6be532ee8d1ac9c
+  languageName: node
+  linkType: hard
+
+"@smithy/util-uri-escape@npm:^4.2.2":
   version: 4.2.2
-  resolution: "@smithy/util-stream@npm:4.2.2"
-  dependencies:
-    "@smithy/fetch-http-handler": ^5.0.4
-    "@smithy/node-http-handler": ^4.0.6
-    "@smithy/types": ^4.3.1
-    "@smithy/util-base64": ^4.0.0
-    "@smithy/util-buffer-from": ^4.0.0
-    "@smithy/util-hex-encoding": ^4.0.0
-    "@smithy/util-utf8": ^4.0.0
-    tslib: ^2.6.2
-  checksum: 52b7c38ccf397536c882fd15453ca4c214618e045fcd96b049e79829f9c5be06a526f3672e88f1f578fa730debead264ce53e6fc3b18f43d8e6079a24ba7bbb0
-  languageName: node
-  linkType: hard
-
-"@smithy/util-uri-escape@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-uri-escape@npm:4.0.0"
+  resolution: "@smithy/util-uri-escape@npm:4.2.2"
   dependencies:
     tslib: ^2.6.2
-  checksum: 7ea350545971f8a009d56e085c34c949c9045862cfab233ee7adc16e111a076a814bb5d9279b2b85ee382e0ed204a1c673ac32e3e28f1073b62a2c53a5dd6d19
+  checksum: c566197aefaa51b80c0e68f78b7ff303c74f831c185da987c00ed49af166ee4f6be64ef56e51c89aa4e1b77c7d875bac81b20856a06b6cf3aaaff808805fbba9
   languageName: node
   linkType: hard
 
@@ -4022,24 +4086,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-utf8@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@smithy/util-utf8@npm:4.0.0"
+"@smithy/util-utf8@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@smithy/util-utf8@npm:4.2.2"
   dependencies:
-    "@smithy/util-buffer-from": ^4.0.0
+    "@smithy/util-buffer-from": ^4.2.2
     tslib: ^2.6.2
-  checksum: 08811c5a18c341782b3b65acc4640a9f559aeba61c889dbdc56e5153a3b7f395e613bfb1ade25cf15311d6237f291e1fce8af197c6313065e0cb084fd2148c64
+  checksum: a507aecdac53570611462a01b192c6e4acec5790efd35c3b0795c4ebf04636b4375ce8d4b6cc254fc9cf1ec72adc9d0263c02c3d0614c902e624d80b37c4d378
   languageName: node
   linkType: hard
 
-"@smithy/util-waiter@npm:^4.0.5":
-  version: 4.0.6
-  resolution: "@smithy/util-waiter@npm:4.0.6"
+"@smithy/util-waiter@npm:^4.2.13":
+  version: 4.2.13
+  resolution: "@smithy/util-waiter@npm:4.2.13"
   dependencies:
-    "@smithy/abort-controller": ^4.0.4
-    "@smithy/types": ^4.3.1
+    "@smithy/abort-controller": ^4.2.12
+    "@smithy/types": ^4.13.1
     tslib: ^2.6.2
-  checksum: 0fb8f5bd351f875f50e4b82845eb427f42d200dd49d39001be3c1f8da6c08383e41c2fcfb5a53fb628211210fe181da30c3c60cb3923805a2063df5cf1be6dd7
+  checksum: 562ea0ed78179a583928c8f69ae782ba9d1715e8af69edc5cd291bc78e1330225e4ce8d727d86b051a7808c2d7c435de4b05951421f158d6944dad18db71068a
+  languageName: node
+  linkType: hard
+
+"@smithy/uuid@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@smithy/uuid@npm:1.1.2"
+  dependencies:
+    tslib: ^2.6.2
+  checksum: 60d2a3d33b615dcdd40c7a59cd2ad89dfe9317dde2115805099bd461fa4aaecd973e92f6bdb4ab588dfccc92d2c726813a744865a1ffacde968ca577d908945d
   languageName: node
   linkType: hard
 
@@ -4163,12 +4236,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/cls-hooked@npm:^4.3.0, @types/cls-hooked@npm:^4.3.3":
+"@types/cls-hooked@npm:^4.3.0":
   version: 4.3.4
   resolution: "@types/cls-hooked@npm:4.3.4"
   dependencies:
     "@types/node": "*"
   checksum: b90cfb32c1d05d47668456a4fd5080090a1786425c80f7d96a9a63d2e2211639aa488c5e7bef0651c0beb62093954a0d7edb98ce519f77cad0fca6ecef9d3b11
+  languageName: node
+  linkType: hard
+
+"@types/cls-hooked@npm:^4.3.3":
+  version: 4.3.9
+  resolution: "@types/cls-hooked@npm:4.3.9"
+  dependencies:
+    "@types/node": "*"
+  checksum: d003c5d3e6f1ebd29c934a3f03c58c65334a2a9ab38106b02514097efca7d4b40a23c387c41764113eea8f508295a53aa72026288a7912902d2e326584937830
   languageName: node
   linkType: hard
 
@@ -4515,13 +4597,6 @@ __metadata:
   version: 3.4.10
   resolution: "@types/uuid@npm:3.4.10"
   checksum: 9905d559a11dfe046b98cf5ea00f635b3c56b87615a8dedb466787d859dfe3616659e50093b211bc0869154cadfb16fa81e02c5c0402dc1508e54913e0c5a631
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^9.0.1":
-  version: 9.0.8
-  resolution: "@types/uuid@npm:9.0.8"
-  checksum: b8c60b7ba8250356b5088302583d1704a4e1a13558d143c549c408bf8920535602ffc12394ede77f8a8083511b023704bc66d1345792714002bfa261b17c5275
   languageName: node
   linkType: hard
 
@@ -5201,8 +5276,8 @@ __metadata:
   linkType: hard
 
 "aws-sdk@npm:^2.814.0":
-  version: 2.1399.0
-  resolution: "aws-sdk@npm:2.1399.0"
+  version: 2.1693.0
+  resolution: "aws-sdk@npm:2.1693.0"
   dependencies:
     buffer: 4.9.2
     events: 1.1.1
@@ -5213,8 +5288,8 @@ __metadata:
     url: 0.10.3
     util: ^0.12.4
     uuid: 8.0.0
-    xml2js: 0.5.0
-  checksum: 74dc46a921cd449749e6a9ba318eb959db0004a21b0c8257660a0cb9727c09b3260f5adb460429d9f362b5c432897df9f7dab3b72dc8c599fdbb96681b132dbc
+    xml2js: 0.6.2
+  checksum: d1487f5f3721bb9d3cbe3d4200759ea328c94d599ca6bbf5ea86e811bccb4eaf566c32282fffac53bdda32c026e0571f1c0e5509326cd9eb20f9c167b4971382
   languageName: node
   linkType: hard
 
@@ -5226,16 +5301,16 @@ __metadata:
   linkType: hard
 
 "aws-xray-sdk-core@npm:^3.3.3":
-  version: 3.5.0
-  resolution: "aws-xray-sdk-core@npm:3.5.0"
+  version: 3.12.0
+  resolution: "aws-xray-sdk-core@npm:3.12.0"
   dependencies:
-    "@aws-sdk/service-error-classification": ^3.4.1
     "@aws-sdk/types": ^3.4.1
+    "@smithy/service-error-classification": ^2.0.4
     "@types/cls-hooked": ^4.3.3
     atomic-batcher: ^1.0.2
     cls-hooked: ^4.2.2
-    semver: ^7.3.8
-  checksum: 136df71a4454d9fb52dc0608088f8308c0cb1c1087d2956c14da72b4f44f53bcd115b3c1740afecdba37fb99f5af21e8bbd2409c1e75f13f0a850e193f6428e5
+    semver: ^7.5.3
+  checksum: a09fdc0661e2418c31cf8b8648338bd9aeaaa9882de48890a922fb7e6b1354f468983b263f5687509eab6d8379d0bbdca4f90cd1444f0bc33d0bf14a4ae5b209
   languageName: node
   linkType: hard
 
@@ -5457,9 +5532,9 @@ __metadata:
   linkType: hard
 
 "bignumber.js@npm:^9.0.1":
-  version: 9.1.1
-  resolution: "bignumber.js@npm:9.1.1"
-  checksum: ad243b7e2f9120b112d670bb3d674128f0bd2ca1745b0a6c9df0433bd2c0252c43e6315d944c2ac07b4c639e7496b425e46842773cf89c6a2dcd4f31e5c4b11e
+  version: 9.3.1
+  resolution: "bignumber.js@npm:9.3.1"
+  checksum: 6ab100271a23a75bb8b99a4b1a34a1a94967ac0b9a52a198147607bd91064e72c6f356380d7a09cd687bf50d81ad2ed1a0a8edfaa90369c9003ed8bb2440d7f0
   languageName: node
   linkType: hard
 
@@ -5498,9 +5573,9 @@ __metadata:
   linkType: hard
 
 "bowser@npm:^2.11.0":
-  version: 2.11.0
-  resolution: "bowser@npm:2.11.0"
-  checksum: 29c3f01f22e703fa6644fc3b684307442df4240b6e10f6cfe1b61c6ca5721073189ca97cdeedb376081148c8518e33b1d818a57f781d70b0b70e1f31fb48814f
+  version: 2.14.1
+  resolution: "bowser@npm:2.14.1"
+  checksum: 5a8b6272c5300b6de416b8508930479cb9028fda597fe3b77f3adbb3959c6bb58ac92b3398c9e9d3652c71e46bce3d6083a611c60c82e9cbaa8ce9698bc9c7af
   languageName: node
   linkType: hard
 
@@ -5775,7 +5850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bound@npm:^1.0.3, call-bound@npm:^1.0.4":
+"call-bound@npm:^1.0.2, call-bound@npm:^1.0.3, call-bound@npm:^1.0.4":
   version: 1.0.4
   resolution: "call-bound@npm:1.0.4"
   dependencies:
@@ -7538,14 +7613,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:4.4.1":
-  version: 4.4.1
-  resolution: "fast-xml-parser@npm:4.4.1"
+"fast-xml-builder@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "fast-xml-builder@npm:1.1.4"
   dependencies:
-    strnum: ^1.0.5
+    path-expression-matcher: ^1.1.3
+  checksum: 90b019ed6f52cb30342a58d4bf8726a7723b4110cb9c0fd3fa2031e87506e8b18740fd349472926c9e2925d22ca6637b6d46a20eda537473cf63366970db4d7b
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:5.5.8":
+  version: 5.5.8
+  resolution: "fast-xml-parser@npm:5.5.8"
+  dependencies:
+    fast-xml-builder: ^1.1.4
+    path-expression-matcher: ^1.2.0
+    strnum: ^2.2.0
   bin:
     fxparser: src/cli/cli.js
-  checksum: f440c01cd141b98789ae777503bcb6727393296094cc82924ae9f88a5b971baa4eec7e65306c7e07746534caa661fc83694ff437d9012dc84dee39dfbfaab947
+  checksum: 58261aaaeb355a325dc1b27ae28e6f8da55e9f8e0560dd752c8a39a4adbaebe560cbbfe924efb44ebf991dbdff76ae6f80a4900d1d03fd720509cb323263bf13
   languageName: node
   linkType: hard
 
@@ -8593,12 +8679,12 @@ __metadata:
   linkType: hard
 
 "is-arguments@npm:^1.0.4":
-  version: 1.1.1
-  resolution: "is-arguments@npm:1.1.1"
+  version: 1.2.0
+  resolution: "is-arguments@npm:1.2.0"
   dependencies:
-    call-bind: ^1.0.2
-    has-tostringtag: ^1.0.0
-  checksum: 7f02700ec2171b691ef3e4d0e3e6c0ba408e8434368504bb593d0d7c891c0dbfda6d19d30808b904a6cb1929bca648c061ba438c39f296c2a8ca083229c49f27
+    call-bound: ^1.0.2
+    has-tostringtag: ^1.0.2
+  checksum: aae9307fedfe2e5be14aebd0f48a9eeedf6b8c8f5a0b66257b965146d1e94abdc3f08e3dce3b1d908e1fa23c70039a88810ee1d753905758b9b6eebbab0bafeb
   languageName: node
   linkType: hard
 
@@ -8779,11 +8865,15 @@ __metadata:
   linkType: hard
 
 "is-generator-function@npm:^1.0.7":
-  version: 1.0.10
-  resolution: "is-generator-function@npm:1.0.10"
+  version: 1.1.2
+  resolution: "is-generator-function@npm:1.1.2"
   dependencies:
-    has-tostringtag: ^1.0.0
-  checksum: d54644e7dbaccef15ceb1e5d91d680eb5068c9ee9f9eb0a9e04173eb5542c9b51b5ab52c5537f5703e48d5fddfd376817c1ca07a84a407b7115b769d4bdde72b
+    call-bound: ^1.0.4
+    generator-function: ^2.0.0
+    get-proto: ^1.0.1
+    has-tostringtag: ^1.0.2
+    safe-regex-test: ^1.1.0
+  checksum: 0b81c613752a5e534939e5b3835ff722446837a5b94c3a3934af5ded36a651d9aa31c3f11f8a3453884b9658bf26dbfb7eb855e744d920b07f084bd890a43414
   languageName: node
   linkType: hard
 
@@ -8861,6 +8951,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-regex@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "is-regex@npm:1.2.1"
+  dependencies:
+    call-bound: ^1.0.2
+    gopd: ^1.2.0
+    has-tostringtag: ^1.0.2
+    hasown: ^2.0.2
+  checksum: 99ee0b6d30ef1bb61fa4b22fae7056c6c9b3c693803c0c284ff7a8570f83075a7d38cda53b06b7996d441215c27895ea5d1af62124562e13d91b3dbec41a5e13
+  languageName: node
+  linkType: hard
+
 "is-shared-array-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-shared-array-buffer@npm:1.0.2"
@@ -8902,7 +9004,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-typed-array@npm:^1.1.10, is-typed-array@npm:^1.1.3, is-typed-array@npm:^1.1.9":
+"is-typed-array@npm:^1.1.10, is-typed-array@npm:^1.1.9":
   version: 1.1.10
   resolution: "is-typed-array@npm:1.1.10"
   dependencies:
@@ -8915,7 +9017,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-typed-array@npm:^1.1.14":
+"is-typed-array@npm:^1.1.14, is-typed-array@npm:^1.1.3":
   version: 1.1.15
   resolution: "is-typed-array@npm:1.1.15"
   dependencies:
@@ -9694,7 +9796,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1, js-yaml@npm:^3.14.1":
+"js-yaml@npm:^3.13.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
   dependencies:
@@ -9703,6 +9805,18 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^3.14.1":
+  version: 3.14.2
+  resolution: "js-yaml@npm:3.14.2"
+  dependencies:
+    argparse: ^1.0.7
+    esprima: ^4.0.0
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 626fc207734a3452d6ba84e1c8c226240e6d431426ed94d0ab043c50926d97c509629c08b1d636f5d27815833b7cfd225865631da9fb33cb957374490bf3e90b
   languageName: node
   linkType: hard
 
@@ -10582,7 +10696,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.14.0, nan@npm:^2.16.0, nan@npm:^2.17.0":
+"nan@npm:^2.14.0, nan@npm:^2.17.0":
   version: 2.17.0
   resolution: "nan@npm:2.17.0"
   dependencies:
@@ -11070,6 +11184,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-expression-matcher@npm:^1.1.3, path-expression-matcher@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "path-expression-matcher@npm:1.2.0"
+  checksum: 2811aab3269c288893aef09e5127124d3c434bfc7e1352fea6b7dd81ed20260001b072ff60bdcaaa393d50a4333725290dbad47bb612d95f5448e499b4ac887f
+  languageName: node
+  linkType: hard
+
 "path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
@@ -11514,10 +11635,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reflect-metadata@npm:*, reflect-metadata@npm:^0.1.10":
+"reflect-metadata@npm:*":
   version: 0.1.13
   resolution: "reflect-metadata@npm:0.1.13"
   checksum: 798d379a7b6f6455501145419505c97dd11cbc23857a386add2b9ef15963ccf15a48d9d15507afe01d4cd74116df8a213247200bac00320bd7c11ddeaa5e8fb4
+  languageName: node
+  linkType: hard
+
+"reflect-metadata@npm:^0.1.10":
+  version: 0.1.14
+  resolution: "reflect-metadata@npm:0.1.14"
+  checksum: 155ad339319cec3c2d9d84719f730f8b6a6cd2a074733ec29dbae6c89d48a2914c7d07a2350212594f3aae160fa4da4f903e6512f27ceaf968443a7c692bcad0
   languageName: node
   linkType: hard
 
@@ -11849,6 +11977,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-regex-test@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "safe-regex-test@npm:1.1.0"
+  dependencies:
+    call-bound: ^1.0.2
+    es-errors: ^1.3.0
+    is-regex: ^1.2.1
+  checksum: 3c809abeb81977c9ed6c869c83aca6873ea0f3ab0f806b8edbba5582d51713f8a6e9757d24d2b4b088f563801475ea946c8e77e7713e8c65cdd02305b6caedab
+  languageName: node
+  linkType: hard
+
 "safe-regex@npm:^1.1.0":
   version: 1.1.0
   resolution: "safe-regex@npm:1.1.0"
@@ -11880,9 +12019,9 @@ __metadata:
   linkType: hard
 
 "sax@npm:>=0.6.0":
-  version: 1.2.4
-  resolution: "sax@npm:1.2.4"
-  checksum: d3df7d32b897a2c2f28e941f732c71ba90e27c24f62ee918bd4d9a8cfb3553f2f81e5493c7f0be94a11c1911b643a9108f231dd6f60df3fa9586b5d2e3e9e1fe
+  version: 1.6.0
+  resolution: "sax@npm:1.6.0"
+  checksum: 83ae2a17f524bd35b1b7d1c867700b1fab41e4cbb4f7635b7e66398421e06ff2cd43ec651c151cb99c67c3681ec7d0493cb6a98fd2e7799ea15b5d0a4615f870
   languageName: node
   linkType: hard
 
@@ -11920,7 +12059,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.2.1, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8":
+"semver@npm:^7.2.1, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
   version: 7.5.2
   resolution: "semver@npm:7.5.2"
   dependencies:
@@ -12641,10 +12780,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^1.0.5":
-  version: 1.1.2
-  resolution: "strnum@npm:1.1.2"
-  checksum: a85219eda13e97151c95e343a9e5960eacfb0a0ff98104b4c9cb7a212e3008bddf0c9714c9c37c2e508be78e741a04afc80027c2dc18509d1b5ffd4c37191fc2
+"strnum@npm:^2.2.0":
+  version: 2.2.2
+  resolution: "strnum@npm:2.2.2"
+  checksum: 9142f1188b12041661353f8d8b658c495fa7b56a0f15d3bb6af38b3473c623ba31eead97aba0ea70956bcde1061fb4802e917a95b825aa939132e18d6320a8fb
   languageName: node
   linkType: hard
 
@@ -13008,14 +13147,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.5.0":
+"tslib@npm:^2.1.0":
   version: 2.5.3
   resolution: "tslib@npm:2.5.3"
   checksum: 88902b309afaf83259131c1e13da1dceb0ad1682a213143a1346a649143924d78cf3760c448b84d796938fd76127183894f8d85cbb3bf9c4fddbfcc140c0003c
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.6.2, tslib@npm:^2.8.1":
+"tslib@npm:^2.5.0, tslib@npm:^2.6.2, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: e4aba30e632b8c8902b47587fd13345e2827fa639e7c3121074d5ee0880723282411a8838f830b55100cbe4517672f84a2472667d355b81e8af165a55dc6203a
@@ -13277,18 +13416,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unix-dgram@npm:2.0.x":
-  version: 2.0.6
-  resolution: "unix-dgram@npm:2.0.6"
-  dependencies:
-    bindings: ^1.5.0
-    nan: ^2.16.0
-    node-gyp: latest
-  checksum: 0ab238726fd69e0a0174664225117b4575b40bd5df546c50a01de2fadf9da602c385ec8ff2f159607a127a6e7bf67628931903d43d286db27460b5abbe8cf8ac
-  languageName: node
-  linkType: hard
-
-"unix-dgram@npm:2.x":
+"unix-dgram@npm:2.0.x, unix-dgram@npm:2.x":
   version: 2.0.7
   resolution: "unix-dgram@npm:2.0.7"
   dependencies:
@@ -13446,15 +13574,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
-  languageName: node
-  linkType: hard
-
 "v8-compile-cache@npm:^2.0.3":
   version: 2.3.0
   resolution: "v8-compile-cache@npm:2.3.0"
@@ -13493,12 +13612,12 @@ __metadata:
   linkType: hard
 
 "watchpack@npm:^2.0.0-beta.10":
-  version: 2.4.1
-  resolution: "watchpack@npm:2.4.1"
+  version: 2.5.1
+  resolution: "watchpack@npm:2.5.1"
   dependencies:
     glob-to-regexp: ^0.4.1
     graceful-fs: ^4.1.2
-  checksum: 5b0179348655dcdf19cac7cb4ff923fdc024d630650c0bf6bec8899cf47c60e19d4f810a88dba692ed0e7f684cf0fcffea86efdbf6c35d81f031e328043b7fab
+  checksum: 44a6030e923fbbe2cbc51cd7fb7abdff58bc35ba68d6c3ca46e63b46f8b3502c7253e6ada384387e946df5515d3854227a84cec49eb88a315186f5c9a67a3e79
   languageName: node
   linkType: hard
 
@@ -13532,7 +13651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.16":
+"which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.2":
   version: 1.1.20
   resolution: "which-typed-array@npm:1.1.20"
   dependencies:
@@ -13547,7 +13666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.2, which-typed-array@npm:^1.1.9":
+"which-typed-array@npm:^1.1.9":
   version: 1.1.9
   resolution: "which-typed-array@npm:1.1.9"
   dependencies:
@@ -13707,13 +13826,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xml2js@npm:0.5.0":
-  version: 0.5.0
-  resolution: "xml2js@npm:0.5.0"
+"xml2js@npm:0.6.2":
+  version: 0.6.2
+  resolution: "xml2js@npm:0.6.2"
   dependencies:
     sax: ">=0.6.0"
     xmlbuilder: ~11.0.0
-  checksum: 1aa71d62e5bc2d89138e3929b9ea46459157727759cbc62ef99484b778641c0cd21fb637696c052d901a22f82d092a3e740a16b4ce218e81ac59b933535124ea
+  checksum: 458a83806193008edff44562c0bdb982801d61ee7867ae58fd35fab781e69e17f40dfeb8fc05391a4648c9c54012066d3955fe5d993ffbe4dc63399023f32ac2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Consumers of `common-aws` were forced to install every dependency (common-server, aws-lambda, datadog-lambda-js, all AWS SDK clients) even when they only needed a single module like `PartitionedKeyValueTable`. This PR breaks that coupling so each subpath carries only the deps it actually uses.

## Summary
- Add `exports` field with 12 subpath entries (`./dynamo/keys`, `./sqs`, `./s3`, etc.) so consumers import only what they need
- Move AWS SDK clients, `common-server`, `aws-lambda`, and `datadog-lambda-js` from direct dependencies to optional peer dependencies (with dev dependencies for local build/test)
- Bump AWS SDK peer deps from `^3.835.0` to `^3.1002.0`
- Remove `dynamoTableName()` and `assertTableNameValid()` — table names are now required, not derived from the runtime environment
- Decouple SQS consumer from implicit `PartitionedKeyValueTable` and environment checks; accept `proxyProvider` via opts
- Extract `DynamoUtil` class from `DynamoDocker` with `createTable` and `removeTable` so table management isn't tied to Docker
- Pass dummy credentials to DynamoDB Docker client so the SDK doesn't try SSO/instance metadata for local containers
- Move `md5`/`consistentMd5` from `common-server` to `common` (re-exported from common-server for compat)
- Create `sns/index.ts` barrel for subpath export consistency
- Remove trivial DynamoTableName type-cast test
- Bump all workspace packages to 3.0.0

## Usage

```typescript
// Before: pulls in everything
import { PartitionedKeyValueTable } from '@paradoxical-io/common-aws';

// After: only needs @aws-sdk/client-dynamodb
import { PartitionedKeyValueTable } from '@paradoxical-io/common-aws/dynamo/keys';
```

## Relevant Gif
![vibe](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2p1NDhqYzZpaXRiMG1uaDE1ODI4djBpNmI3NzFwdjVzcXFlbjAxYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3og0IutJ8QecjD2SK4/giphy.gif)